### PR TITLE
Improvements to `brace`

### DIFF
--- a/manual.typ
+++ b/manual.typ
@@ -1091,6 +1091,7 @@ content((rel: (.3, .1), to: "hill.center"), text[*εїз*])
 #def-arg("pointiness", `<number> or <angle>`, default: 15deg, [How pointy the spike should be. #0deg or `0` for maximum pointiness, #90deg or `1` for minimum.])
 #def-arg("outer-pointiness", `<number> or <angle> or <auto>`, default: 0, [How pointy the outer edges should be. #0deg or `0` for maximum pointiness (allowing for a smooth transition to a straight line), #90deg or `1` for minimum. Setting this to #auto will use the value set for `pointiness`.])
 #def-arg("content-offset", `<number>`, default: .3, [Offset of the `content` anchor from the spike.])
+#def-arg("debug-text-size", `<length>`, default: 6pt, [Font size of displayed debug points when `debug` is #true.])
 
 ==== Default `brace` Style
 #decorations.brace-default-style

--- a/manual.typ
+++ b/manual.typ
@@ -1063,22 +1063,34 @@ Various pre-made shapes and lines.
 #show-module-fn(decorations-module, "brace")
 ```example
 import cetz.decorations: brace
-brace((0, 0), (4, -.5), pointiness: 25deg, amplitude: .8, debug: true)
+let text = text.with(size: 12pt, font: "Linux Libertine")
+
+brace((0, 0), (4, -.5), pointiness: 25deg, outer-pointiness: auto, amplitude: .8, debug: true)
 brace((0, -.5), (0, -3.5), name: "brace")
 content("brace.content", [$P_1$])
 
 // styling can be passed to the underlying `merge-path` call
-brace((1.5, -2), (4.5, -2), amplitude: 1, pointiness: .5, stroke: orange + 2pt, fill: maroon, close: true, name: "saloon")
-content((rel: (0, -.15), to: "saloon.center"), text(12pt, fill: orange, font: "Linux Libertine", smallcaps[*Saloon*]))
+brace((1, -3), (4, -3), amplitude: 1, pointiness: .5, stroke: orange + 2pt, fill: maroon, close: true, name: "saloon")
+content((rel: (0, -.15), to: "saloon.center"), text(fill: orange, smallcaps[*Saloon*]))
 
 // as part of another path
-set-origin((3, -3))
+set-origin((2, -5))
 merge-path({
   brace((+1, .5), (+1, -.5), amplitude: .3, pointiness: .5)
   brace((-1, .5), (-1, -.5), amplitude: .3, pointiness: .5, flip: true)
 }, fill: white, close: true)
-content((0, 0), text(.8em)[Hello, World!])
+content((0, 0), text(size: 10pt)[Hello, World!])
+
+brace((-1.5, -2.5), (2, -2.5), pointiness: 1, outer-pointiness: 1, stroke: olive, fill: green, name: "hill")
+content((rel: (.3, .1), to: "hill.center"), text[εїз])
 ```
+
+#STYLING
+
+#def-arg("amplitude", `<number>`, default: .7, [Determines how much the brace rises above the base line.])
+#def-arg("pointiness", `<number> or <angle>`, default: 15deg, [How pointy the spike should be. #0deg or `0` for maximum pointiness, #90deg or `1` for minimum.])
+#def-arg("outer-pointiness", `<number> or <angle> or <auto>`, default: 0, [How pointy the outer edges should be. #0deg or `0` for maximum pointiness (allowing for a smooth transition to a straight line), #90deg or `1` for minimum. Setting this to #auto will use the value set for `pointiness`.])
+#def-arg("content-offset", `<number>`, default: .3, [Offset of the `content` anchor from the spike.])
 
 ==== Default `brace` Style
 #decorations.brace-default-style

--- a/manual.typ
+++ b/manual.typ
@@ -1077,12 +1077,12 @@ content((rel: (0, -.15), to: "saloon.center"), text(fill: orange, smallcaps[*Sal
 set-origin((2, -5))
 merge-path({
   brace((+1, .5), (+1, -.5), amplitude: .3, pointiness: .5)
-  brace((-1, .5), (-1, -.5), amplitude: .3, pointiness: .5, flip: true)
+  brace((-1, -.5), (-1, .5), amplitude: .3, pointiness: .5)
 }, fill: white, close: true)
 content((0, 0), text(size: 10pt)[Hello, World!])
 
 brace((-1.5, -2.5), (2, -2.5), pointiness: 1, outer-pointiness: 1, stroke: olive, fill: green, name: "hill")
-content((rel: (.3, .1), to: "hill.center"), text[εїз])
+content((rel: (.3, .1), to: "hill.center"), text[*εїз*])
 ```
 
 #STYLING

--- a/src/lib/decorations.typ
+++ b/src/lib/decorations.typ
@@ -37,7 +37,7 @@
 ///
 /// - start (coordinate): Start point
 /// - end (coordinate): End point
-/// - flip (bool): Flip the brace around, same as swapping the start and end points
+/// - flip (bool): Flip the brace around
 /// - debug (bool): Show debug lines and points
 /// - name (string, none): Element name
 /// - ..style (style): Style attributes
@@ -51,11 +51,6 @@
 ) = {
   // validate coordinates
   let t = (start, end).map(coordinate.resolve-system)
-
-  // flipping is achieved by swapping the start and end points, the parameter is just for convenience
-  if flip {
-    (start, end) = (end, start)
-  }
 
   group(name: name, ctx => {
     // get styles and validate types and values
@@ -100,6 +95,13 @@
       type(content-offset) in (int, float),
       message: "content-offset must be a number",
     )
+
+    // we flip the brace by inverting the amplitude and pointiness values
+    if flip {
+      amplitude *= -1
+      pointiness *= -1
+      outer-pointiness *= -1
+    }
 
     // 'abcd' is a rectangle with the base line 'ab' and the height 'amplitude'
     let a = start
@@ -169,5 +171,5 @@
     }
   })
   // move to end point so the current position after this is the end position
-  move-to(if flip { start } else { end })
+  move-to(end)
 }

--- a/src/lib/decorations.typ
+++ b/src/lib/decorations.typ
@@ -20,6 +20,7 @@
   pointiness: 15deg,
   outer-pointiness: 0,
   content-offset: .3,
+  debug-text-size: 6pt,
 )
 
 /// Draw a curly brace between two points.
@@ -166,7 +167,7 @@
     // label all points in debug mode
     if debug {
       for (name, point) in points {
-        content(point, box(fill: luma(240), inset: .5pt, text(6pt, raw(name))))
+        content(point, box(fill: luma(240), inset: .5pt, text(style.debug-text-size, raw(name))))
       }
     }
   })

--- a/src/lib/decorations.typ
+++ b/src/lib/decorations.typ
@@ -60,7 +60,7 @@
     let amplitude = style.amplitude
     assert(
       type(amplitude) in (int, float),
-      message: "amplitude must be a number",
+      message: "amplitude must be a number, got " + repr(amplitude),
     )
 
     let pointiness = style.pointiness
@@ -69,7 +69,7 @@
         and pointiness >= 0 and pointiness <= 1
       or type(pointiness) == angle
         and pointiness >= 0deg and pointiness <= 90deg,
-      message: "pointiness must be a factor between 0 and 1 or an angle between 0deg and 90deg",
+      message: "pointiness must be a factor between 0 and 1 or an angle between 0deg and 90deg, got " + repr(pointiness),
     )
     let pointiness = if type(pointiness) == angle { pointiness } else { pointiness * 90deg }
 
@@ -80,7 +80,7 @@
         and outer-pointiness >= 0 and outer-pointiness <= 1
       or type(outer-pointiness) == angle
         and outer-pointiness >= 0deg and outer-pointiness <= 90deg,
-      message: "outer-pointiness must be a factor between 0 and 1 or an angle between 0deg and 90deg or auto",
+      message: "outer-pointiness must be a factor between 0 and 1 or an angle between 0deg and 90deg or auto, got " + repr(outer-pointiness),
     )
     let outer-pointiness = if outer-pointiness == auto {
       pointiness
@@ -93,7 +93,7 @@
     let content-offset = style.content-offset
     assert(
       type(content-offset) in (int, float),
-      message: "content-offset must be a number",
+      message: "content-offset must be a number, got " + repr(content-offset),
     )
 
     // we flip the brace by inverting the amplitude and pointiness values

--- a/src/lib/decorations.typ
+++ b/src/lib/decorations.typ
@@ -169,5 +169,5 @@
     }
   })
   // move to end point so the current position after this is the end position
-  move-to(end)
+  move-to(if flip { start } else { end })
 }


### PR DESCRIPTION
This PR adds a new style key called `outer-pointiness` for the braces from the `decorations` library. It effectively controls the same thing as the existing `pointiness` but for the outer points instead. This adds the two new debug points `i` and `j` (what was `i` before is now `k`). Setting this to `0` (as is the default) provides the same behaviour as before.

I also moved documentation of the style keys from the function's doc-comment to the `manual.typ` file just like the other elements do it.

Screenshot of the updated example:
![image](https://github.com/johannes-wolf/cetz/assets/35602040/f7ac66b5-829f-4f55-ab51-96b30f116712)

I am also second guessing my choice from yesterday in #227 that a pointiness of 0 is the maximum. Intuitively I would expect 1 to be the max, but then again with the angles it makes sense to have `0deg` as the max :shrug:. If you think we should change this I could quickly edit this PR or create another one, but that would of course immediately break backwards compatibility with v0.1.2.

---

Also unrelated to the PR: I noticed the example code in the manual is justified which I think doesn't look good in code snippets. And the default font inside the example canvases is also monospace.