### PR TITLE
Introducing the dendrogram

### DIFF
--- a/src/lib/chart.typ
+++ b/src/lib/chart.typ
@@ -4,6 +4,8 @@
 #import "palette.typ"
 #import "../draw.typ"
 
+#import "chart/dendrogram.typ": dendrogram
+
 // Styles
 #let barchart-default-style = (
   axes: (tick: (length: 0))

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -53,6 +53,26 @@
 ///                           rows `.at(..)` function.
 /// - mode (string): Chart mode:
 ///                  - `"vertical"` -- Vertically displayed dendrogram
+/// - size (array): Chart size as width and height tuple in canvas units;
+///                 height can be set to `auto`.
+/// - line-style (style,function): Style or function (idx => style) to use for
+///                               each leaf, accepts a palette function.
+/// - x-label (content,none): X axis label
+/// - y-tick-step (float): Step size of y axis ticks 
+/// - x-ticks (array): List of tick values or value/label tuples
+///
+///                    *Example*
+///                    
+///                    `(1, 5, 10)` or `((1, [One]), (2, [Two]), (10, [Ten]))`
+/// - y-ticks (array): List of tick values or value/label tuples
+///
+///                    *Example*
+///                    
+///                    `(1, 5, 10)` or `((1, [One]), (2, [Two]), (10, [Ten]))`
+/// - y-unit (content,auto): Tick suffix added to each tick label
+/// - y-label (content,none): Y axis label
+/// - y-min (number,auto): Y axis minimum value
+/// - y-max (number,auto): Y axis maximum value
 #let dendrogram(data,
                  x1-key: 0,
                  x2-key: 1,
@@ -61,7 +81,6 @@
                  size: (auto, 1),
                  line-style: (stroke: black + 1pt),
                  x-label: none,
-                 x-tick-step: none,
                  y-tick-step: auto,
                  x-ticks: auto,
                  y-ticks: (),
@@ -78,7 +97,7 @@
     assert(type(height-key) in (int, str))
 
     if size.at(0) == auto {
-      size.at(0) = (data.len() + 1)
+      size.at(0) = (data.len() + 2)
     }
 
     let max-value = (dendrogram-max-value-fn.at(mode))(data, height-key)
@@ -106,7 +125,7 @@
                       max: data.len() + 2,
                       label: x-label,
                       ticks: (list: x-ticks,
-                              grid: none, step: x-tick-step,
+                              grid: none, step: none,
                               minor-step: none,
                       ))
     let y = axes.axis(min: min-value, max: max-value,

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -3,7 +3,7 @@
 #import "../../draw.typ"
 
 #let dendrogram-default-style = (
-  axes: (tick: (length: 0))
+  axes: (:)
 )
 
 // Valid dendrogram modes
@@ -33,7 +33,7 @@
                  height-key: 2,
                  mode: "basic",
                  size: (auto, 1),
-                 dendrogram-style: (stroke: black + 1pt),
+                 line-style: (stroke: black + 1pt),
                  x-label: none,
                  x-tick-step: none,
                  y-tick-step: auto,
@@ -93,8 +93,8 @@
     let basic-draw-dendrogram(data, ..style) = {
 
         let data_mut = data // Mutable
-        let dendrogram-style = dendrogram-style;
-        if type(dendrogram-style) != function { dendrogram-style = ((i) => dendrogram-style) }
+        let line-style = line-style;
+        if type(line-style) != function { line-style = ((i) => line-style) }
         
         for (idx, entry) in data.enumerate() {
 
@@ -119,7 +119,7 @@
 
             merge-path(
               line((x1, y1),(x1, height),(x2, height),(x2, y2)),
-              ..style, ..dendrogram-style(idx))
+              ..style, ..line-style(idx))
 
             data_mut.push((
                 (x1 + x2)/2,

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -1,0 +1,158 @@
+#import "../axes.typ"
+#import "../palette.typ"
+#import "../../draw.typ"
+
+#let dendrogram-default-style = (
+  axes: (tick: (length: 0))
+)
+
+// Valid dendrogram modes
+#let dendrogram-modes = (
+  "basic",
+)
+
+// Functions for max value calculation
+#let dendrogram-max-value-fn = (
+  basic: (data, value-key) => {
+    calc.max(0, ..data.map(t => t.at(value-key)))
+  },
+)
+
+// Functions for min value calculation
+#let dendrogram-min-value-fn = (
+  basic: (data, value-key) => {
+    calc.min(0, ..data.map(t => t.at(value-key)))
+  },
+)
+
+// TODO:
+
+#let dendrogram(data,
+                 x1-key: 0,
+                 x2-key: 1,
+                 height-key: 2,
+                 mode: "basic",
+                 size: (auto, 1),
+                 dendrogram-style: (stroke: black + 1pt),
+                 x-label: none,
+                 x-tick-step: none,
+                 y-tick-step: auto,
+                 x-ticks: auto,
+                 y-ticks: (),
+                 y-unit: auto,
+                 y-label: none,
+                 y-min: auto,
+                 y-max: auto,
+                 ) = {
+    import draw: *
+
+    assert(mode in dendrogram-modes,message: "Invalid dendrogram mode")
+    assert(type(x1-key) in (int, str))
+    assert(type(x2-key) in (int, str))
+    assert(type(height-key) in (int, str))
+
+    if size.at(0) == auto {
+      size.at(0) = (data.len() + 1)
+    }
+
+    let max-value = (dendrogram-max-value-fn.at(mode))(data, height-key)
+    if y-max != auto {
+      max-value = y-max
+    }
+    let min-value = (dendrogram-min-value-fn.at(mode))(data, height-key)
+    if y-min != auto {
+      min-value = y-min
+    }
+
+    let x-ticks = x-ticks
+    if ( x-ticks == auto ){
+        x-ticks = range(0, data.len()*2 - 1).map(it=>{
+            (it, it)
+        })
+    }
+
+    let y-unit = y-unit
+    if y-unit == auto {
+      y-unit = /*if mode == "stacked100" {[%]} else*/ []
+    }
+    
+    let x = axes.axis(min: 0, 
+                      max: data.len() + 2,
+                      label: x-label,
+                      ticks: (list: x-ticks,
+                              grid: none, step: x-tick-step,
+                              minor-step: none,
+                      ))
+    let y = axes.axis(min: min-value, max: max-value,
+                      label: y-label,
+                      ticks: (grid: true, step: y-tick-step,
+                              minor-step: none,
+                              unit: y-unit, decimals: 1,
+                              list: y-ticks))
+
+    let basic-draw-dendrogram(data, ..style) = {
+
+        let data_mut = data // Mutable
+        let dendrogram-style = dendrogram-style;
+        if type(dendrogram-style) != function { dendrogram-style = ((i) => dendrogram-style) }
+        
+        for (idx, entry) in data.enumerate() {
+
+            let height = entry.at(height-key)
+            let x1 = entry.at(x1-key)
+            let x2 = entry.at(x2-key)
+
+            let y1 = 0
+            let y2 = 0
+
+            if ( x1 > (data.len()+1) ){
+                let child = data_mut.at(x1 - 2)
+                x1 = child.at(x1-key)
+                y1 = child.at(height-key)
+            }
+
+            if ( x2 > (data.len())+1){
+                let child = data_mut.at(x2 - 2)
+                x2 = child.at(x1-key)
+                y2 = child.at(height-key)
+            }
+
+            merge-path({
+                line((x1, y1), (x1, height))
+                line((x1, height), (x2, height))
+                line((x2, height),(x2, y2))
+            }, ..style, ..dendrogram-style(idx))
+
+            data_mut.push((
+                (x1 + x2)/2,
+                (x1 + x2)/2,
+                height
+            ))
+
+        }
+
+    }
+
+    let draw-data = (
+      if mode == "basic" {basic-draw-dendrogram}
+    )
+
+    group(ctx => {
+      let style = util.merge-dictionary(dendrogram-default-style,
+        styles.resolve(ctx.style, (:), root: "dendrogram"))
+
+      axes.scientific(size: size,
+                      left: y,
+                      right: none,
+                      bottom: x,
+                      top: none,
+                      frame: "set",
+                      ..style.axes)
+      if data.len() > 0 {
+
+        axes.axis-viewport(size, x, y, {
+            draw-data(data)
+        })
+      }
+    })
+}

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -92,7 +92,7 @@
 
     let basic-draw-dendrogram(data, ..style) = {
 
-        let data_mut = data // Mutable
+        let data-mut = data // Mutable
         let line-style = line-style;
         if type(line-style) != function { line-style = ((i) => line-style) }
         

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -117,11 +117,9 @@
                 y2 = child.at(height-key)
             }
 
-            merge-path({
-                line((x1, y1), (x1, height))
-                line((x1, height), (x2, height))
-                line((x2, height),(x2, y2))
-            }, ..style, ..dendrogram-style(idx))
+            merge-path(
+              line((x1, y1),(x1, height),(x2, height),(x2, y2)),
+              ..style, ..dendrogram-style(idx))
 
             data_mut.push((
                 (x1 + x2)/2,

--- a/src/lib/chart/dendrogram.typ
+++ b/src/lib/chart/dendrogram.typ
@@ -8,30 +8,56 @@
 
 // Valid dendrogram modes
 #let dendrogram-modes = (
-  "basic",
+  "vertical",
 )
 
 // Functions for max value calculation
 #let dendrogram-max-value-fn = (
-  basic: (data, value-key) => {
+  vertical: (data, value-key) => {
     calc.max(0, ..data.map(t => t.at(value-key)))
   },
 )
 
 // Functions for min value calculation
 #let dendrogram-min-value-fn = (
-  basic: (data, value-key) => {
+  vertical: (data, value-key) => {
     calc.min(0, ..data.map(t => t.at(value-key)))
   },
 )
 
 // TODO:
 
+/// Draw a dendrogram. A dendrogram is a chat that relative distances higher
+/// dimensional spaces. It if often used by data scientists in clustering
+/// analyses.
+///
+/// *Style root*: `dendrogram`.
+///
+/// - data (array): Array of data rows, with each entry representing a leaf on
+///                 the dendrogram.A row can be of type array or dictionary,
+///                 with `x1-key`, `x2-key`, and `height-key` being the keys
+///                 used to axcess a row's links and heights.
+///
+///                 *Example*
+///                 ```typc
+///                 ((1, 2, 0.5),(3, 4, 1),(6, 7, 2),(5, 8, 2.5))
+///                 ```
+/// - x1-key (int,string): Key to access the first cluster of a data row. This 
+///                        key is used as argument to the rows `.at(..)` 
+///                        function.
+/// - x2-key (int,string): Key to access the second cluster of a data row. 
+///                        This key is used as argument to the rows `.at(..)` 
+///                        function.
+/// - value-key (int,string): Key(s) to access value(s) of data row.
+///                           These keys are used as argument to the
+///                           rows `.at(..)` function.
+/// - mode (string): Chart mode:
+///                  - `"vertical"` -- Vertically displayed dendrogram
 #let dendrogram(data,
                  x1-key: 0,
                  x2-key: 1,
                  height-key: 2,
-                 mode: "basic",
+                 mode: "vertical",
                  size: (auto, 1),
                  line-style: (stroke: black + 1pt),
                  x-label: none,
@@ -90,7 +116,7 @@
                               unit: y-unit, decimals: 1,
                               list: y-ticks))
 
-    let basic-draw-dendrogram(data, ..style) = {
+    let vertical-draw-dendrogram(data, ..style) = {
 
         let data-mut = data // Mutable
         let line-style = line-style;
@@ -106,13 +132,13 @@
             let y2 = 0
 
             if ( x1 > (data.len()+1) ){
-                let child = data_mut.at(x1 - 2)
+                let child = data-mut.at(x1 - 2)
                 x1 = child.at(x1-key)
                 y1 = child.at(height-key)
             }
 
             if ( x2 > (data.len())+1){
-                let child = data_mut.at(x2 - 2)
+                let child = data-mut.at(x2 - 2)
                 x2 = child.at(x1-key)
                 y2 = child.at(height-key)
             }
@@ -121,7 +147,7 @@
               line((x1, y1),(x1, height),(x2, height),(x2, y2)),
               ..style, ..line-style(idx))
 
-            data_mut.push((
+            data-mut.push((
                 (x1 + x2)/2,
                 (x1 + x2)/2,
                 height
@@ -132,7 +158,7 @@
     }
 
     let draw-data = (
-      if mode == "basic" {basic-draw-dendrogram}
+      if mode == "vertical" {vertical-draw-dendrogram}
     )
 
     group(ctx => {

--- a/tests/chart/dendrogram/test.typ
+++ b/tests/chart/dendrogram/test.typ
@@ -18,7 +18,7 @@
         (4,[B2]),
         (5,[Control])
     ),
-    dendrogram-style: (idx)=>{
+    line-style: (idx)=>{
         if idx in (0,){ return (stroke: red + 1pt)}
         if idx in (1,){ return (stroke: green + 1pt)}
         //if idx in (2,){ return (stroke: blue + 1pt)}

--- a/tests/chart/dendrogram/test.typ
+++ b/tests/chart/dendrogram/test.typ
@@ -8,9 +8,8 @@
     (5, 8, 2.5000)
 )
 
-#canvas({
-  chart.dendrogram(
-    size: (10, 10),
+#let settings = (
+    size: (auto, 6),
     x-ticks: (
         (1,[S1]),
         (2,[S2]),
@@ -19,9 +18,21 @@
         (5,[Control])
     ),
     line-style: (idx)=>{
-        if idx in (0,){ return (stroke: red + 1pt)}
-        if idx in (1,){ return (stroke: green + 1pt)}
-        //if idx in (2,){ return (stroke: blue + 1pt)}
+        if idx in (0,){ return (stroke: red)}
+        if idx in (1,){ return (stroke: green)}
+        return (stroke: black)
     },
+)
+
+#box(stroke: 2pt + red, canvas({
+  chart.dendrogram(
+    ..settings,
     dendrogram-data)
-})
+}))
+
+#box(stroke: 2pt + red, canvas({
+  chart.dendrogram(
+    ..settings,
+    dendrogram-data,
+    mode:"horizontal")
+}))

--- a/tests/chart/dendrogram/test.typ
+++ b/tests/chart/dendrogram/test.typ
@@ -1,0 +1,27 @@
+#set page(width: auto, height: auto)
+#import "../../../src/lib.typ": *
+
+#let dendrogram-data = (
+    (1, 2, 0.5000),
+    (3, 4, 1.0000),
+    (6, 7, 2.0616),
+    (5, 8, 2.5000)
+)
+
+#canvas({
+  chart.dendrogram(
+    size: (10, 10),
+    x-ticks: (
+        (1,[S1]),
+        (2,[S2]),
+        (3,[B1]),
+        (4,[B2]),
+        (5,[Control])
+    ),
+    dendrogram-style: (idx)=>{
+        if idx in (0,){ return (stroke: red + 1pt)}
+        if idx in (1,){ return (stroke: green + 1pt)}
+        //if idx in (2,){ return (stroke: blue + 1pt)}
+    },
+    dendrogram-data)
+})

--- a/tests/chart/dendrogram/test.typ
+++ b/tests/chart/dendrogram/test.typ
@@ -1,5 +1,5 @@
 #set page(width: auto, height: auto)
-#import "../../../src/lib.typ": *
+#import "/src/lib.typ": *
 
 #let dendrogram-data = (
     (1, 2, 0.5000),


### PR DESCRIPTION
Dendrogram chart for displaying linkages of binary clusters. Currently supports individual styling of leaves. Would be commonly used in clustering analyses. Input format matches that of matlab.

```typst
#set page(width: auto, height: auto)
#import "../../../src/lib.typ": *

#let dendrogram-data = (
    (1, 2, 0.5000),
    (3, 4, 1.0000),
    (6, 7, 2.0616),
    (5, 8, 2.5000)
)

#canvas({
  chart.dendrogram(
    size: (10, 10),
    x-ticks: (
        (1,[S1]),
        (2,[S2]),
        (3,[B1]),
        (4,[B2]),
        (5,[Control])
    ),
    dendrogram-style: (idx)=>{
        if idx in (0,){ return (stroke: red + 1pt)}
        if idx in (1,){ return (stroke: green + 1pt)}
        //if idx in (2,){ return (stroke: blue + 1pt)}
    },
    dendrogram-data)
})
```

![image](https://github.com/johannes-wolf/cetz/assets/6299280/d935ebc4-1826-47df-b9b6-6d0aeffca665)
