### PR TITLE
matrix: Unroll matrix-vector product

### DIFF
--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -123,6 +123,23 @@
   )
 }
 
+// Multiply 4x4 matrix with vector of size 3 or 4.
+// The value of vec_4 defaults to w (1).
+//
+// The resulting vector is of dimension 3
+#let mul4x4-vec3(mat, vec, w: 1) = {
+  assert(vec.len() <= 4)
+  let out = (0, 0, 0)
+  for m in range(0, 3) {
+    let v = (mat.at(m).at(0) * vec.at(0, default: 0)
+           + mat.at(m).at(1) * vec.at(1, default: 0)
+           + mat.at(m).at(2) * vec.at(2, default: 0)
+           + mat.at(m).at(3) * vec.at(3, default: w))
+    out.at(m) = v
+  }
+  return out
+}
+
 // Multiply matrix with vector
 #let mul-vec(mat, vec) = {
   if mat.len() != vector.dim(vec) {

--- a/src/util.typ
+++ b/src/util.typ
@@ -14,10 +14,8 @@
 /// - ..vecs (vectors): Vectors to get transformed. Only the positional part of the sink is used. A dictionary of vectors can be passed and all will be transformed.
 /// -> vectors If multiple vectors are given they are returned as an array, if only one vector is given only one will be returned, if a dictionary is given they will be returned in the dictionary with the same keys.
 #let apply-transform(transform, ..vecs) = {
-  let t = vec => matrix.mul-vec(
-      transform, 
-      vector.as-vec(vec, init: (0, 0, 0, 1))
-    ).slice(0, 3)
+  let t = vec => matrix.mul4x4-vec3(
+    transform, vec)
   if type(vecs.pos().first()) == dictionary {
     vecs = vecs.pos().first()
     for (k, vec) in vecs {


### PR DESCRIPTION
This change gives about -100 ms for a line plot with 1000 data points.
Since matrix-vector multiplication is done a lot, this specialization should be used. 
We actually never user non 4x4 matrices, so we could think about not supporting other matrix sizes in general.