### PR TITLE
tests: Support test filters

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,11 +10,11 @@ package target:
 install:
   ./scripts/package "@local"
 
-test:
-  ./scripts/test test
+test *filter:
+  ./scripts/test test {{filter}}
 
-update-test:
-  ./scripts/test update
+update-test *filter:
+  ./scripts/test update {{filter}}
 
 manual:
   typst c manual.typ manual.pdf

--- a/scripts/test
+++ b/scripts/test
@@ -7,6 +7,11 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 MODE="${1:-test}";
 if (( $# > 1)); then shift; fi
 
+# Test filter strings
+FILTER="${*}"
+FILTER="${FILTER// /|}"
+export FILTER
+
 TYPST_ROOT="$(realpath "$DIR/..")"
 export TYPST_ROOT
 TEST_ROOT="$(realpath "$DIR/../tests")"
@@ -52,7 +57,7 @@ function update_test_ref()
   (
     cd "$1"
     local NAME
-    NAME="$(basename "$1")"
+    NAME="$(realpath "$1" --relative-to "$TEST_ROOT")"
 
     echo "[UPDATING] ${NAME}"
 
@@ -122,7 +127,8 @@ fi
 # Collects all test directories. A directory is a test dir. if it
 # contains a file called test.typ.
 function tests() {
-  find "$TEST_ROOT" -type f -name "test.typ" -exec dirname {} \;
+  find "$TEST_ROOT" -type f -name "test.typ" -exec dirname {} \; \
+    | grep -E "${FILTER}"
 }
 
 if [[ "$MODE" == "test" ]]; then


### PR DESCRIPTION
This allows to run tests by name (regexp):
   
    just test plot
    just test plot anchor

All filter strings are concatted to one regexp by "|" and passed to grep.