### PR TITLE
canvas: Fix bug when using canvas insides tablex

### DIFF
--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -23,9 +23,10 @@
   let length = if type(length) == ratio {
     length * ly.width
   } else {
-    measure(line(length: length), st).width
+    measure(box(width: length, height: length), st).width
   }
-
+  assert(length / 1cm != 0,
+    message: "Canvas length must be != 0!")
 
   let ctx = (
     typst-style: st,


### PR DESCRIPTION
Fixes #345.

For some reason, `line` measures 0pt in width (with `length: 1cm`). This only happens insides `tablex`. Using `box` works.