### PR TITLE
Remove -n 1 argument from xargs in test script

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -123,7 +123,7 @@ echo "Typst: $(typst --version)"
 # we fake it by forwarding it's call to xargs
 if ! hash parallel 2>/dev/null; then
   function parallel() {
-    xargs -n 1 -I {} bash -c "$1"
+    xargs -I {} bash -c "$1"
   }
 fi
 


### PR DESCRIPTION
`--max-args` (`-n`) is mutually exclusive with `-I` (since `-I` implies a single argument); using both causes a warning.

![xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value](https://github.com/johannes-wolf/cetz/assets/43387454/72e5f252-2604-48df-a43e-22d50cbf16cb)

This just gets rid of that warning.

I'm looking to win the "most inconsequential pull request of all time" competition with this one 😛