### PR TITLE
Mark improvements

### DIFF
--- a/mark old.typ
+++ b/mark old.typ
@@ -1,0 +1,714 @@
+#let typst-length = length
+#import "bezier.typ"
+#import "drawable.typ"
+#import "vector.typ"
+#import "util.typ"
+#import "path-util.typ"
+
+/// Prepare mark style by resolving all stroke-thickness relative
+/// values to absolute ones.
+///
+/// -> dictionary
+#let prepare-mark-style(ctx, style) = {
+  let thickness = util.get-stroke(style.stroke).thickness
+  if type(thickness) == length { thickness /= 1pt }
+
+  let scale = style.scale
+  if type(scale) == ratio { scale = thickness * scale / 100% }
+
+  let width = style.width
+  if type(width) == ratio { width = thickness * width / 100% }
+  width *= scale
+
+  let length = style.length
+  if type(length) == ratio { length = thickness * length / 100% }
+  length *= scale
+
+  let inset = style.inset
+  if type(inset) == ratio { inset = thickness * inset / 100% }
+  inset *= scale
+
+  let sep = style.sep
+  if type(sep) == ratio { sep = thickness * sep / 100% }
+
+  // Reset the scale to 1 because we pre-scaled all values
+  style.scale = 1
+  style.width = width
+  style.length = length
+  style.inset = inset
+  style.sep = sep
+  return style
+}
+
+/// Draw a triangle mark with optional inset
+#let draw-triangle(dir, norm, tip, style, open: false) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.length))
+
+  if open {
+    (drawable.path(path-util.line-segment((vector.add(b, w), tip, vector.sub(b, w))),
+       stroke: style.stroke, fill: none, close: false),)
+  } else if style.inset == 0 {
+    (drawable.path(path-util.line-segment((vector.add(b, w), tip, vector.sub(b, w))),
+       stroke: style.stroke, fill: style.fill, close: true),)
+  } else {
+    let i = vector.add(b, vector.scale(dir, style.inset))
+    (drawable.path(path-util.line-segment((vector.add(b, w), tip, vector.sub(b, w), i)),
+       stroke: style.stroke, fill: style.fill, close: true),)
+  }
+}
+
+/// Draw a diamond/rotated square
+#let draw-diamond(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.length))
+  let m = vector.sub(tip, vector.scale(dir, style.length / 2))
+
+  (drawable.path(path-util.line-segment((
+     tip, vector.add(m, w), b, vector.sub(m, w))),
+     stroke: style.stroke, fill: style.fill, close: true),)
+}
+
+// Draw a barbed/math arrow
+#let draw-barbed(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.length))
+
+  (drawable.path(
+     (path-util.cubic-segment(vector.add(b, w), tip, vector.add(b, w), b),
+      path-util.cubic-segment(tip, vector.sub(b, w), b, vector.sub(b, w))),
+     stroke: style.stroke, fill: none, close: false),)
+}
+
+/// Draw a bar
+#let draw-bar(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+
+  (drawable.path(
+     path-util.line-segment((vector.add(tip, w), vector.sub(tip, w))),
+     stroke: style.stroke, close: false),)
+}
+
+/// Draw a bracket with
+#let draw-bracket(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.length))
+
+  (drawable.path(
+     path-util.line-segment((vector.add(b, w),
+                             vector.add(tip, w),
+                             vector.sub(tip, w),
+                             vector.sub(b, w))),
+     stroke: style.stroke, close: false),)
+}
+
+/// Draw a star with n lines
+#let draw-star(dir, norm, tip, style, n: 5, angle-offset: 0deg) = {
+  return range(0, n).map(i => {
+    let a = i * 360deg / n + angle-offset
+    let d = vector.scale(vector.rotate-z(norm, a), style.width / 2)
+
+    drawable.path(path-util.line-segment((tip, vector.add(tip, d))),
+      stroke: style.stroke, close: false)
+  })
+}
+
+/// Draw a circle
+#let draw-circle(dir, norm, tip, style) = {
+  let o = vector.sub(tip, vector.scale(dir, style.width / 2))
+
+  (drawable.ellipse(..o, style.width / 2, style.width / 2,
+     stroke: style.stroke, fill: style.fill),)
+}
+
+/// Draw a rect
+#let draw-rect(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.length))
+
+  (drawable.path(path-util.line-segment((
+    vector.add(b, w), vector.add(tip, w),
+    vector.sub(tip, w), vector.sub(b, w))),
+    stroke: style.stroke, fill: style.fill, close: true),)
+}
+
+/// Draw a round hook
+#let draw-hook(dir, norm, tip, style) = {
+  let w = vector.scale(norm, style.width / 2)
+  let b = vector.sub(tip, vector.scale(dir, style.width / 2))
+
+  (drawable.path(path-util.cubic-segment(
+    b, vector.add(b, w), tip, vector.add(tip, w)),
+    stroke: style.stroke, fill: none, close: false),)
+}
+
+// Calculate offset for a triangular mark (triangle, harpoon, ..)
+#let _triangular-mark-offset(ctx, mark-width, mark-length, symbol, style) = {
+  let stroke = line(stroke: style.stroke).stroke
+  let (width, limit, join) = (
+    stroke.thickness, stroke.miter-limit, stroke.join)
+
+  // Fallback to Typst's defaults
+  if width == auto { width = 1pt }
+  if limit == auto { limit = 4 }
+  if join  == auto { join = "miter" }
+
+  if type(width) == typst-length { width /= ctx.length }
+
+  if style.length == 0 { return 0 }
+  let angle = calc.atan(mark-width / (2 * mark-length)) * 2
+  if join == "miter" {
+    let angle = calc.abs(angle)
+    let miter = if angle == 180deg {
+      width / 2
+    } else if angle == 0deg or angle == 360deg {
+      0
+    } else {
+      (1 / calc.sin(angle / 2) * width / 2)
+    }
+
+    if calc.abs(2 * miter / width) <= limit {
+      return -miter
+    } else {
+      // If the miter limit kicks in, use bevel calculation
+      join = "bevel"
+    }
+  }
+
+  if join == "bevel" {
+    return -calc.sin(angle / 2) * width / 2
+  } else {
+    return width / -2
+  }
+}
+
+/// Public list of all predefined mark symbols
+#let mark-symbols = (
+  ">", "<", "->", "<-", "~>", "<~", "|", "[", "]", "o", "<>", "[]", "*", "+", "x", "hook", "hook-right",
+)
+
+/// Returns a tuple of a draw-function and a mark offset
+#let get-mark(ctx, symbol, index, style) = {
+  let thickness = util.get-stroke(style.stroke).thickness / 2
+  if type(thickness) == length { thickness /= ctx.length }
+
+  assert(type(symbol) in (str, dictionary),
+    message: "Invalid mark symbol type: " + type(symbol))
+  let mark = if symbol in (">", "<") {(
+    draw: draw-triangle,
+    offset: _triangular-mark-offset(ctx, style.width, style.length, symbol, style),
+    length: style.length - style.inset,
+    reverse: symbol == "<"
+  )} else if symbol in ("->", "<-") {(
+    draw: draw-triangle.with(open: true),
+    offset: _triangular-mark-offset(ctx, style.width, style.length, symbol, style),
+    gap: style.length,
+    reverse: symbol == "<-"
+  )} else if symbol in ("~>", "<~") {(
+    draw: draw-barbed,
+    offset: _triangular-mark-offset(ctx, 0, style.length, symbol, style),
+    gap: style.length,
+    reverse: symbol == "<~"
+  )} else if symbol == "|" {(
+    draw: draw-bar,
+  )} else if symbol in ("]", "[") {(
+    draw: draw-bracket,
+    gap: style.length,
+    offset: -thickness,
+    reverse: symbol == "["
+  )} else if symbol == "[]" {(
+    draw: draw-rect,
+    length: style.length,
+    offset: -thickness,
+  )} else if symbol == "<>" {(
+    draw: draw-diamond,
+    offset: _triangular-mark-offset(ctx, style.width, style.length / 2, symbol, style),
+    length: style.length
+  )} else if symbol == "o" {(
+    draw: draw-circle,
+    length: style.width,
+    offset: -thickness,
+  )} else if symbol == "*" {(
+    draw: draw-star,
+    gap: style.length
+  )} else if symbol == "+" {(
+    draw: draw-star.with(n: 4),
+    gap: style.length
+  )} else if symbol == "x" {(
+    draw: draw-star.with(n: 4, angle-offset: 45deg),
+    gap: style.length
+  )} else if symbol in ("hook", "hook-right") {(
+    draw: draw-hook,
+    offset: thickness,
+    length: style.width / 2,
+    flip: symbol == "hook-right"
+  )} else if type(symbol) == dictionary {
+    assert("draw" in symbol and type(symbol.draw) == function,
+      message: "Mark dictionary must contain 'draw' function: " + repr(symbol))
+    symbol
+  } else {
+    panic("Invalid mark symbol: " + symbol)
+  }
+
+  mark.reverse = mark.at("reverse", default: false)
+  mark.reverse = mark.reverse != style.reverse
+  let dir-factor = if mark.reverse { -1 } else { 1 }
+  mark.offset = dir-factor * mark.at("offset", default: 0)
+  mark.flip = mark.at("flip", default: false)
+  mark.flip = mark.flip != style.flip
+  let norm-factor = if mark.flip { -1 } else { 1 }
+
+  if dir-factor != 1 or norm-factor != 1 {
+    mark.draw = (dir, norm, tip, style) => {
+      let dir = vector.scale(dir, dir-factor)
+      let norm = vector.scale(norm, dir-factor * norm-factor)
+      (mark.draw)(dir, norm, tip, style)
+    }
+  }
+
+  return mark
+}
+
+#let prepare-start-end(ctx, style) = {
+  let start = if type(style.start) == str {
+    (style.start,)
+  } else if style.start == none {
+    ()
+  } else {
+    style.start
+  }.enumerate().map(((i, sym)) => get-mark(ctx, sym, i, style))
+
+  let end = if type(style.end) == str {
+    (style.end,)
+  } else if style.end == none {
+    ()
+  } else {
+    style.end
+  }.enumerate().map(((i, sym)) => get-mark(ctx, sym, i, style))
+
+  return (start, end)
+}
+
+// Calculate norm mark direction between two points
+#let calc-dir(from, to, style) = {
+  let dir = vector.sub(to, from)
+  if dir == (0,0,0) {
+    dir = (1,0,0)
+  } else {
+    dir = vector.norm(dir)
+  }
+
+  return dir
+}
+
+#let calc-normal(dir, style) = {
+  let norm = (-dir.at(1), dir.at(0), dir.at(2))
+
+  // 3D support
+  if norm.at(2) != 0 {
+    norm = vector.norm(vector.cross(norm, style.z-up))
+  }
+
+  // Slanting
+  if style.slant != none and style.slant != 0deg {
+    norm = vector.rotate-z(norm, style.slant)
+  }
+
+  return norm
+}
+
+/// Place marks along line of points
+///
+/// - ctx (context): Context
+/// - pts (array): Array of vectors
+/// - style (style): Mark style dictionary
+/// -> (drawables, pts) Tuple of drawables and adjusted line points
+#let place-marks-along-line(ctx, pts, style) = {
+  let style = prepare-mark-style(ctx, style)
+  let (start, end) = prepare-start-end(ctx, style)
+
+  // Offset start
+  let start-pt = pts.at(0)
+  if start.len() > 0 {
+    let mark = start.at(0)
+    let offset = mark.at("offset", default: 0)
+
+    let dir = vector.sub(pts.at(0), pts.at(1))
+    if vector.len(dir) != 0 {
+      let dir = vector.norm(dir)
+      start-pt = vector.add(start-pt, vector.scale(dir, offset))
+    }
+  }
+
+  // Offset end
+  let end-pt = pts.at(-1)
+  if end.len() > 0 {
+    let mark = end.at(0)
+    let offset = mark.at("offset", default: 0)
+
+    let dir = vector.sub(pts.at(-2), pts.at(-1))
+    if vector.len(dir) != 0 {
+      let dir = vector.norm(dir)
+      end-pt = vector.sub(end-pt, vector.scale(dir, offset))
+    }
+  }
+
+  let drawables = ()
+
+  // Draw start marks
+  if start != none {
+    let dir = calc-dir(pts.at(1), pts.at(0), style)
+    let norm = calc-normal(dir, style)
+
+    let pt = start-pt
+    for (i, m) in start.enumerate() {
+      let tip = pt
+      drawables += (m.draw)(dir, norm, tip, style)
+
+      let off = vector.scale(dir, m.at("length", default: 0))
+      pt = vector.sub(pt, off)
+
+      if style.shorten-to == auto or style.shorten-to == i {
+         pts.at(0) = if m.reverse { tip } else { pt }
+      }
+
+      let gap = vector.scale(dir, m.at("gap", default: 0) + style.sep)
+      pt = vector.sub(pt, gap)
+    }
+  }
+
+  // Draw end marks
+  if end != none {
+    let dir = calc-dir(pts.at(-2), pts.at(-1), style)
+    let norm = calc-normal(dir, style)
+
+    let pt = end-pt
+    for (i, m) in end.enumerate() {
+      let tip = pt
+      drawables += (m.draw)(dir, norm, tip, style)
+
+      let off = vector.scale(dir, m.at("length", default: 0))
+      pt = vector.sub(pt, off)
+
+      if style.shorten-to == auto or style.shorten-to == i {
+        pts.at(-1) = if m.reverse { tip } else { pt }
+      }
+
+      let gap = vector.scale(dir, m.at("gap", default: 0) + style.sep)
+      pt = vector.sub(pt, gap)
+    }
+  }
+
+  return (drawables, pts)
+}
+
+// Shorten curve by distance
+#let _shorten-curve(curve, distance, target-pt, style, start: true) = {
+  assert(style.shorten in ("LINEAR", "CURVED"),
+    message: "Invalid cubic shorten style")
+  let quick = style.shorten == "LINEAR"
+  curve = if quick {
+    if target-pt == none {
+      bezier.cubic-shorten-linear(..curve, distance)
+    } else {
+      curve
+    }
+  } else {
+    bezier.cubic-shorten(..curve, distance)
+  }
+
+  // Snap curve to point
+  if target-pt != none {
+    if start {
+      curve.at(0) = target-pt
+    } else {
+      curve.at(1) = target-pt
+    }
+  }
+
+  return curve
+}
+
+/// Place marks along a cubic bezier curve
+///
+/// - ctx (context): Context
+/// - curve (array): Array of curve points (start, end, ctrl-1, ctrl-2)
+/// - style (style): Curve style
+/// - mark-style (style): Mark style
+/// -> (drawables, curve) Tuple of drawables and adjusted curve points
+#let place-marks-along-bezier(ctx, curve, style, mark-style) = {
+  let samples = calc.max(2, calc.min(mark-style.position-samples, 1000))
+  let mark-style = prepare-mark-style(ctx, mark-style)
+  let (start, end) = prepare-start-end(ctx, mark-style)
+
+  // Offset start
+  if start.len() > 0 {
+    let mark = start.at(0)
+    let offset = mark.at("offset", default: 0)
+    let dir = bezier.cubic-derivative(..curve, 0)
+    let opt = if vector.len(dir) != 0 {
+      vector.sub(curve.at(0), vector.scale(vector.norm(dir), offset))
+    }
+    curve = _shorten-curve(curve, calc.max(0, -offset), opt, style, start: true)
+  }
+
+  // Offset end
+  if end.len() > 0 {
+    let mark = end.at(0)
+    let offset = mark.at("offset", default: 0)
+    let dir = bezier.cubic-derivative(..curve, 1)
+    let opt = if vector.len(dir) != 0 {
+      vector.add(curve.at(1), vector.scale(vector.norm(dir), offset))
+    }
+    curve = _shorten-curve(curve, calc.min(0, offset), opt, style, start: false)
+  }
+
+  let drawables = ()
+  let flex = mark-style.flex
+
+  let min-sample-length = 0.0001
+  let shorten-start = 0; let pt-start = none
+  let shorten-end = 0; let pt-end = none
+
+  // Draw start mark-style
+  if start != none {
+    let dist = 0
+    for (i, m) in start.enumerate() {
+      let t = if dist > 0 {
+        bezier.cubic-t-for-distance(..curve, dist, samples: samples)
+      } else {
+        0
+      }
+
+      let pt = bezier.cubic-point(..curve, t)
+      let dir = if flex {
+        let t-base = bezier.cubic-t-for-distance(..curve, dist + m.at("length", default: 0) + min-sample-length,
+          samples: samples)
+        vector.sub(pt, bezier.cubic-point(..curve, t-base))
+      } else {
+        vector.scale(bezier.cubic-derivative(..curve, t), -1)
+      }
+      if vector.len(dir) == 0 {break} // TODO: Emit warning
+
+      dir = vector.norm(dir)
+      let norm = calc-normal(dir, mark-style)
+
+      let tip = pt
+      let old-dist = dist
+      drawables += (m.draw)(dir, norm, tip, mark-style)
+      dist += m.at("length", default: 0)
+
+      if mark-style.shorten-to == auto or mark-style.shorten-to == i {
+        shorten-start = if m.reverse {
+          old-dist
+        } else {
+          dist
+        }
+        pt-start = if m.reverse {
+          tip
+        } else {
+          vector.sub(pt, vector.scale(dir, m.at("length", default: 0)))
+        }
+      }
+
+      dist += m.at("gap", default: 0) + mark-style.sep
+    }
+  }
+
+  // Draw end mark-style
+  if end != none {
+    let dist = 0
+    for (i, m) in end.enumerate() {
+      let t = if dist > 0 {
+        bezier.cubic-t-for-distance(..curve, -dist, samples: samples)
+      } else {
+        1
+      }
+
+      let pt = bezier.cubic-point(..curve, t)
+      let dir = if flex {
+        let t-base = bezier.cubic-t-for-distance(..curve, -dist - m.at("length", default: 0) - min-sample-length,
+          samples: samples)
+        vector.sub(pt, bezier.cubic-point(..curve, t-base))
+      } else {
+        bezier.cubic-derivative(..curve, t)
+      }
+      if vector.len(dir) == 0 {break} // TODO: Emit warning
+
+      dir = vector.norm(dir)
+      let norm = calc-normal(dir, mark-style)
+
+      let tip = pt
+      let old-dist = dist
+      drawables += (m.draw)(dir, norm, tip, mark-style)
+      dist += m.at("length", default: 0)
+
+      if mark-style.shorten-to == auto or mark-style.shorten-to == i {
+        shorten-end = if m.reverse {
+          old-dist
+        } else {
+          dist
+        }
+        pt-end = if m.reverse {
+          tip
+        } else {
+          vector.sub(pt, vector.scale(dir, m.at("length", default: 0)))
+        }
+      }
+
+      if m.reverse {
+        dist += m.at("length", default: 0)
+      }
+
+      dist += m.at("gap", default: 0) + mark-style.sep
+    }
+  }
+
+  curve = _shorten-curve(curve, calc.max(0, shorten-start), pt-start, style, start: true)
+  curve = _shorten-curve(curve, calc.min(0, -shorten-end), pt-end, style, start: false)
+
+  return (drawables, curve)
+}
+
+/// Place marks along a list of cubic bezier curves
+///
+/// - ctx (context): Context
+/// - curves (array): Array of curves
+/// - style (style): Curve style
+/// - mark-style (style): Mark style
+/// -> (drawables, curves) Tuple of drawables and adjusted curves
+#let place-marks-along-beziers(ctx, curves, style, mark-style) = {
+  if curves.len() == 1 {
+    let (marks, curve) = place-marks-along-bezier(
+      ctx, curves.at(0), style, mark-style)
+    return (marks, (curve,))
+  } else {
+    // TODO: This has the limitation that only the first curve of
+    //       the catmull-rom is used for placing marks.
+    let start-mark-style = mark-style
+    start-mark-style.end = none
+    let (start-marks, start-curve) = place-marks-along-bezier(
+      ctx, curves.at(0), style, start-mark-style)
+
+    let end-mark-style = mark-style
+    end-mark-style.start = none
+    let (end-marks, end-curve) = place-marks-along-bezier(
+      ctx, curves.at(-1), style, end-mark-style)
+    curves.at(0) = start-curve
+    curves.at(-1) = end-curve
+    return (start-marks + end-marks, curves)
+  }
+}
+
+#let place-marks-along-arc(ctx, start-angle, stop-angle, arc-start,
+                           rx, ry, style, mark-style) = {
+  let adjust = style.at("mode", default: "OPEN") == "OPEN"
+
+  let r-at(angle) = calc.sqrt(calc.pow(calc.cos(angle) * ry, 2) +
+                              calc.pow(calc.sin(angle) * rx, 2))
+
+  let (start, end) = prepare-start-end(ctx, mark-style)
+
+  // Offset start
+  if start.len() > 0 {
+    let mark = start.at(0)
+    let off = mark.at("offset", default: 0)
+
+    // Remember original start
+    let orig-start = start-angle
+
+    // Calc an optimized start angle
+    let r = r-at(start-angle)
+    start-angle -= (off * 360deg) / (2 * calc.pi * r)
+
+    // Reposition the arc
+    let diff = vector.sub((calc.cos(start-angle) * rx, calc.sin(start-angle) * ry),
+                          (calc.cos(orig-start) * rx, calc.sin(orig-start) * ry))
+    arc-start = vector.add(arc-start, diff)
+  }
+
+  // Offset end
+  if end.len() > 0 {
+    let mark = end.at(0)
+    let off = mark.at("offset", default: 0)
+
+    let r = r-at(stop-angle)
+    stop-angle += (off * 360deg) / (2 * calc.pi * r)
+  }
+
+  let arc-center = vector.sub(arc-start, (calc.cos(start-angle) * rx,
+                                          calc.sin(start-angle) * ry))
+  let pt-at(angle) = vector.add(arc-center,
+    (calc.cos(angle) * rx, calc.sin(angle) * ry, 0))
+
+  let orig-start = start-angle
+  let drawables = ()
+
+  // Draw start marks
+  let angle = start-angle
+  for (i, m) in start.enumerate() {
+    let length = calc.max(m.at("length", default: 0), 0.0001)
+    let r = r-at(angle)
+    let angle-offset = (length * 360deg) / (2 * calc.pi * r)
+
+    let pt = pt-at(angle)
+
+    let dir = vector.norm(vector.sub(pt, pt-at(angle + angle-offset)))
+    let norm = calc-normal(dir, mark-style)
+
+    let old-angle = angle
+    drawables += (m.draw)(dir, norm, pt, mark-style)
+
+    if mark-style.shorten-to == auto or mark-style.shorten-to == i {
+      start-angle = if m.reverse {
+        old-angle
+      } else {
+        angle + angle-offset
+      }
+    }
+
+    let angle-offset = ((length + m.at("gap", default: 0) + mark-style.sep) * 360deg) / (2 * calc.pi * r)
+    angle += angle-offset
+  }
+
+  // Reposition the arc
+  if orig-start != start-angle {
+    let diff = vector.sub((calc.cos(start-angle) * rx, calc.sin(start-angle) * ry),
+                          (calc.cos(orig-start) * rx, calc.sin(orig-start) * ry))
+    arc-start = vector.add(arc-start, diff)
+  }
+
+  // Draw end marks
+  let angle = stop-angle
+  for (i, m) in end.enumerate() {
+    let length = calc.max(m.at("length", default: 0), 0.0001)
+    let r = r-at(angle)
+
+    let angle-offset = (length * 360deg) / (2 * calc.pi * r)
+
+    let pt = pt-at(angle)
+
+    let dir = vector.norm(vector.sub(pt, pt-at(angle - angle-offset)))
+    let norm = calc-normal(dir, mark-style)
+
+    let old-angle = angle
+    drawables += (m.draw)(dir, norm, pt, mark-style)
+
+    if mark-style.shorten-to == auto or mark-style.shorten-to == i {
+      stop-angle = if m.reverse {
+        old-angle
+      } else {
+        angle - angle-offset
+      }
+    }
+
+    let angle-offset = ((length + m.at("gap", default: 0) + mark-style.sep) * 360deg) / (2 * calc.pi * r)
+    angle -= angle-offset
+  }
+
+  return (drawables, arc-start, start-angle, stop-angle)
+}
+
+#let place-marks-along-path(ctx, style, segments) = {
+  
+}

--- a/src/bezier.typ
+++ b/src/bezier.typ
@@ -233,7 +233,7 @@
   let (left, right) = split-rec((s, c1, c2, e), t, (), ())
 
   return ((left.at(0), left.at(3), left.at(1), left.at(2)),
-          (right.at(0), right.at(3), right.at(1), right.at(2)))
+          (right.at(3), right.at(0), right.at(2), right.at(1)))
 }
 
 /// Approximate cubic curve length

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -115,6 +115,9 @@
           }
         }
 
+        if type(drawable.stroke) == dictionary and type(drawable.stroke.thickness) != typst-length {
+          drawable.stroke.thickness *= length
+        }
         path(
           stroke: drawable.stroke,
           fill: drawable.fill,

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -114,8 +114,7 @@
             vertices += coordinates
           }
         }
-
-        if type(drawable.stroke) == dictionary and type(drawable.stroke.thickness) != typst-length {
+        if type(drawable.stroke) == dictionary and "thickness" in drawable.stroke and type(drawable.stroke.thickness) != typst-length {
           drawable.stroke.thickness *= length
         }
         path(

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1226,15 +1226,16 @@
       }
 
       let style = styles.resolve(ctx.style, merge: style, root: "bezier")
-      let curve = (start, end, ..ctrl)
-      let (marks, curve) = if style.mark != none {
-        mark_.place-marks-along-bezier(ctx, curve, style, style.mark)
+
+      let segments = (path-util.cubic-segment(start, end, ..ctrl),)
+      let (marks, segments) = if style.mark != none {
+        mark_.place-marks-along-path(ctx, style.mark, segments)
       } else {
-        (none, curve)
+        (none, segments)
       }
 
       let path = drawable.path(
-        path-util.cubic-segment(..curve),
+        segments,
         fill: style.fill,
         stroke: style.stroke,
       )

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1244,7 +1244,7 @@
         path.segments = segments
         path = (path,) + marks
       }
-
+      // panic(drawables)
       return (
         ctx: ctx, 
         name: name,

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -593,16 +593,16 @@
 
     let style = styles.resolve(ctx.style, merge: style, root: "line")
 
-    // Place marks and adjust points
-    let (marks, pts) = if style.mark != none {
-      mark_.place-marks-along-line(ctx, pts, style.mark)
+    // Place marks and adjust segments
+    let (marks, segments) = if style.mark.start != none or style.mark.end != none {
+      mark_.place-marks-along-path(ctx, style.mark, (path-util.line-segment(pts),))
     } else {
-      (none, pts)
+      (none, (path-util.line-segment(pts),))
     }
 
     // Line path
     let path = drawable.path(
-      (path-util.line-segment(pts),),
+      segments,
       fill: style.fill,
       stroke: style.stroke,
       close: close)

--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -11,6 +11,7 @@
     return ()
   }
   for drawable in drawables {
+    assert(type(drawable) != array, message: repr(drawables))
     if drawable.type == "path" {
       drawable.segments = drawable.segments.map(s => {
         return (s.at(0),) + util.apply-transform(transform, ..s.slice(1))

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -2,370 +2,55 @@
 #import "bezier.typ"
 #import "drawable.typ"
 #import "vector.typ"
+#import "matrix.typ"
 #import "util.typ"
 #import "path-util.typ"
 
-// Calculate offset for a triangular mark (triangle, harpoon, ..)
-#let _triangular-mark-offset(ctx, mark-width, mark-length, symbol, style) = {
-  let revert = symbol == "<"
-  let sign = if revert { 1 } else { -1 }
+// <-
+// (style) => drawables
+#let marks = (
+  triangle: (style) => (
+    drawables: drawable.path(
+      path-util.line-segment(
+        (
+          (0, 0),
+          (style.length, style.width/2),
+          (style.length, -style.width/2)
+        )
+      ),
+      close: true,
+      fill: style.fill,
+      stroke: style.stroke
+    ),
+    distance: style.length
+  )
+)
 
-  let stroke = line(stroke: style.stroke).stroke
-  let (width, limit, join) = (
-    stroke.thickness, stroke.miter-limit, stroke.join)
+#let place-marks-along-path(ctx, style, segments) = {
+  let thickness = util.get-stroke(style.stroke).thickness
 
-  // Fallback to Typst's defaults
-  if width == auto { width = 1pt }
-  if limit == auto { limit = 4 }
-  if join  == auto { join = "miter" }
-
-  if type(width) == typst-length { width /= ctx.length }
-
-  if style.length == 0 { return 0 }
-  let angle = calc.atan(mark-width / (2 * mark-length)) * 2
-  if join == "miter" {
-    let angle = calc.abs(angle)
-    let miter = if angle == 180deg {
-      width / 2
-    } else if angle == 0deg or angle == 360deg {
-      0
-    } else {
-      (1 / calc.sin(angle / 2) * width / 2)
-    }
-
-    if calc.abs(2 * miter / width) <= limit {
-      return miter * sign
-    } else {
-      // If the miter limit kicks in, use bevel calculation
-      join = "bevel"
-    }
-  }
-
-  if join == "bevel" {
-    return calc.sin(angle / 2) * width / 2 * sign
-  } else {
-    return width / 2 * sign
-  }
-}
-
-// Calculate the offset of a mark symbol.
-// For triangular marks, this is the half
-// of the miter length or halt of the stroke
-// thickness, depending on the joint style.
-#let calc-mark-offset(ctx, symbol, style) = {
-  if symbol in ("<", ">") {
-    return _triangular-mark-offset(ctx, style.width, style.length, symbol, style)
-  } else if symbol in ("left-harpoon", "right-harpoon") {
-    return _triangular-mark-offset(ctx, style.width / 2, style.length, symbol, style)
-  } else if symbol == "<>" {
-    return _triangular-mark-offset(ctx, style.width, style.length / 2, symbol, style)
-  } else {
-    // Offset by half the strok width to have the stroke edge touch
-    // the target position.
-    let width = line(stroke: style.stroke).stroke.thickness
-    if width == auto { width = 1pt }
-    if type(width) == length { width /= ctx.length }
-
-    return -width / 2
-  }
-}
-
-// Get mark symbol mid length, that is the length from the tip to the mid-point
-// of its base. For triangular shaped marks, that is the distance between tip and
-// inset.
-#let mark-mid-length(symbol, style) = {
-  let scale = style.scale
-  let length = style.length * scale
-
-  if symbol in ("<", ">", "left-harpoon", "right-harpoon") {
-    return length - style.inset * scale
-  }
-
-  return length
-}
-
-/// Place marks along line of points
-///
-/// - ctx (context): Context
-/// - pts (array): Array of vectors
-/// - style (style): Mark style dictionary
-/// -> (drawables, pts) Tuple of drawables and adjusted line points
-#let place-marks-along-line(ctx, pts, style) = {
-  let start = if type(style.start) == str {
-    (style.start,)
-  } else {
-    style.start
-  }
-
-  // Offset start
-  if start != none and start.len() > 0 {
-    let off = calc-mark-offset(ctx, start.at(0), style)
-    let dir = vector.norm(vector.sub(pts.at(1), pts.at(0)))
-
-    pts.at(0) = vector.sub(pts.at(0), vector.scale(dir, off))
-  }
-
-  let end = if type(style.end) == str {
-    (style.end,)
-  } else {
-    style.end
-  }
-
-  // Offset end
-  if end != none and end.len() > 0 {
-    let off = calc-mark-offset(ctx, end.at(0), style)
-    let dir = vector.norm(vector.sub(pts.at(-2), pts.at(-1)))
-
-    pts.at(-1) = vector.sub(pts.at(-1), vector.scale(dir, off))
-  }
-
-  let drawables = ()
-
-  // Draw start marks
-  if start != none {
-    let dir = vector.norm(vector.sub(pts.at(1), pts.at(0)))
-    let pt = pts.at(0)
-    for m in start {
-      drawables.push(drawable.mark(
-        vector.add(pt, dir), pt, m, style))
-      pt = vector.add(pt, vector.scale(dir, mark-mid-length(m, style) + style.sep))
-    }
-  }
-
-  // Draw end marks
-  if end != none {
-    let dir = vector.norm(vector.sub(pts.at(-1), pts.at(-2)))
-    let pt = pts.at(-1)
-    for m in end {
-      drawables.push(drawable.mark(
-        vector.sub(pt, dir), pt, m, style))
-      pt = vector.sub(pt, vector.scale(dir, mark-mid-length(m, style) + style.sep))
-    }
-  }
-
-  return (drawables, pts)
-}
-
-// Shorten curve by distance
-#let _shorten-curve(curve, distance, style) = {
-  assert(style.shorten in ("LINEAR", "CURVED"),
-    message: "Invalid cubic shorten style")
-  let quick = style.shorten == "LINEAR"
-  if quick {
-    return bezier.cubic-shorten-linear(..curve, distance)
-  } else {
-    return bezier.cubic-shorten(..curve, distance)
-  }
-}
-
-/// Place marks along a cubic bezier curve
-///
-/// - ctx (context): Context
-/// - curve (array): Array of curve points (start, end, ctrl-1, ctrl-2)
-/// - style (style): Curve style
-/// - mark-style (style): Mark style
-/// -> (drawables, curve) Tuple of drawables and adjusted curve points
-#let place-marks-along-bezier(ctx, curve, style, mark-style) = {
-  let samples = calc.max(2, calc.min(mark-style.position-samples, 1000))
-
-  let start = if type(mark-style.start) == str {
-    (mark-style.start,)
-  } else {
-    mark-style.start
-  }
-
-  // Offset start
-  if start != none and start.len() > 0 {
-    let off = calc-mark-offset(ctx, start.at(0), mark-style)
-    curve = _shorten-curve(curve, calc.max(0, -off), style)
-  }
-
-  let end = if type(mark-style.end) == str {
-    (mark-style.end,)
-  } else {
-    mark-style.end
-  }
-
-  // Offset end
-  if end != none and end.len() > 0 {
-    let off = calc-mark-offset(ctx, end.at(0), mark-style)
-    curve = _shorten-curve(curve, calc.min(0, off), style)
-  }
-
-  let drawables = ()
-  let flex = mark-style.flex
-
-  // Draw start mark-style
-  if start != none {
-    let dist = 0
-    for m in start {
-      let t = if dist > 0 {
-        bezier.cubic-t-for-distance(..curve, dist, samples: samples)
+  for (k, v) in style {
+    if k in ("length", "width", "inset", "sep") {
+      style.insert(k, if type(v) == ratio {
+        thickness * v
       } else {
-        0
-      }
-
-      let pt = bezier.cubic-point(..curve, t)
-      let dir = if flex {
-        let t-base = bezier.cubic-t-for-distance(..curve, dist + mark-mid-length(m, mark-style),
-          samples: samples)
-        vector.sub(bezier.cubic-point(..curve, t-base), pt)
-      } else {
-        bezier.cubic-derivative(..curve, t)
-      }
-      if vector.len(dir) == 0 {break} // TODO: Emit warning
-
-      drawables.push(drawable.mark(
-        vector.add(pt, dir), pt, m, mark-style))
-
-      dist += mark-mid-length(m, mark-style) + mark-style.sep
+        util.resolve-number(ctx, v)
+      } * style.scale)
     }
   }
 
-  // Draw end mark-style
-  if end != none {
-    let dist = 0
-    for m in end {
-      let t = if dist > 0 {
-        bezier.cubic-t-for-distance(..curve, -dist, samples: samples)
-      } else {
-        1
-      }
+  let (drawables, distance) = (marks.triangle)(style)
 
-      let pt = bezier.cubic-point(..curve, t)
-      let dir = if flex {
-        let t-base = bezier.cubic-t-for-distance(..curve, -dist - mark-mid-length(m, mark-style),
-          samples: samples)
-        vector.sub(pt, bezier.cubic-point(..curve, t-base))
-      } else {
-        bezier.cubic-derivative(..curve, t)
-      }
-      if vector.len(dir) == 0 {break} // TODO: Emit warning
+  let (pos, dir) = path-util.direction(segments, 0)
+  dir = vector.angle2(pos, dir) + 0deg
+  let transform = matrix.mul-mat(
+    matrix.transform-translate(..pos),
+    matrix.transform-rotate-z(dir),
+  )
+  drawables = drawable.apply-transform(transform, drawables)
 
-      drawables.push(drawable.mark(
-        vector.sub(pt, dir), pt, m, mark-style))
+  segments = path-util.shorten-path(segments, distance, 0)
 
-      dist += mark-mid-length(m, mark-style) + mark-style.sep
-    }
-  }
+  return (drawables, segments)
 
-  return (drawables, curve)
-}
-
-/// Place marks along a list of cubic bezier curves
-///
-/// - ctx (context): Context
-/// - curves (array): Array of curves
-/// - style (style): Curve style
-/// - mark-style (style): Mark style
-/// -> (drawables, curves) Tuple of drawables and adjusted curves
-#let place-marks-along-beziers(ctx, curves, style, mark-style) = {
-  if curves.len() == 1 {
-    let (marks, curve) = place-marks-along-bezier(
-      ctx, curves.at(0), style, mark-style)
-    return (marks, (curve,))
-  } else {
-    // TODO: This has the limitation that only the first curve of
-    //       the catmull-rom is used for placing marks.
-    let start-mark-style = mark-style
-    start-mark-style.end = none
-    let (start-marks, start-curve) = place-marks-along-bezier(
-      ctx, curves.at(0), style, start-mark-style)
-
-    let end-mark-style = mark-style
-    end-mark-style.start = none
-    let (end-marks, end-curve) = place-marks-along-bezier(
-      ctx, curves.at(-1), style, end-mark-style)
-    curves.at(0) = start-curve
-    curves.at(-1) = end-curve
-    return (start-marks + end-marks, curves)
-  }
-}
-
-#let place-marks-along-arc(ctx, start-angle, stop-angle, arc-start,
-                           rx, ry, style, mark-style) = {
-  let adjust = style.at("mode", default: "OPEN") == "OPEN"
-
-  let r-at(angle) = calc.sqrt(calc.pow(calc.cos(angle) * ry, 2) +
-                              calc.pow(calc.sin(angle) * rx, 2))
-
-  let start = if type(mark-style.start) == str {
-    (mark-style.start,)
-  } else {
-    mark-style.start
-  }
-
-  // Offset start
-  if start != none and start.len() > 0 {
-    let off = calc-mark-offset(ctx, start.at(0), mark-style)
-
-    // Remember original start
-    let orig-start = start-angle
-
-    // Calc an optimized start angle
-    let r = r-at(start-angle)
-    start-angle -= (off * 360deg) / (2 * calc.pi * r)
-
-    // Reposition the arc
-    let diff = vector.sub((calc.cos(start-angle) * rx, calc.sin(start-angle) * ry),
-                          (calc.cos(orig-start) * rx, calc.sin(orig-start) * ry))
-    arc-start = vector.add(arc-start, diff)
-  }
-
-  let end = if type(mark-style.end) == str {
-    (mark-style.end,)
-  } else {
-    mark-style.end
-  }
-
-  // Offset end
-  if end != none and end.len() > 0 {
-    let off = calc-mark-offset(ctx, end.at(0), mark-style)
-
-    let r = r-at(stop-angle)
-    stop-angle += (off * 360deg) / (2 * calc.pi * r)
-  }
-
-  let arc-center = vector.sub(arc-start, (calc.cos(start-angle) * rx,
-                                          calc.sin(start-angle) * ry))
-  let pt-at(angle) = vector.add(arc-center,
-    (calc.cos(angle) * rx, calc.sin(angle) * ry, 0))
-
-  let drawables = ()
-
-  // Draw start marks
-  if start != none {
-    let angle = start-angle
-    for m in start {
-      let length = mark-mid-length(m, mark-style)
-      let r = r-at(angle)
-      let angle-offset = (length * 360deg) / (2 * calc.pi * r)
-
-      let pt = pt-at(angle)
-      drawables.push(drawable.mark(
-        pt-at(angle + angle-offset), pt, m, mark-style))
-
-      let angle-offset = ((length + mark-style.sep) * 360deg) / (2 * calc.pi * r)
-      angle += angle-offset
-    }
-  }
-
-  // Draw end marks
-  if end != none {
-    let angle = stop-angle
-    for m in end {
-      let length = mark-mid-length(m, mark-style)
-      let r = r-at(angle)
-      let angle-offset = (length * 360deg) / (2 * calc.pi * r)
-
-      let pt = pt-at(angle)
-      drawables.push(drawable.mark(
-        pt-at(angle - angle-offset), pt, m, mark-style))
-
-      let angle-offset = ((length + mark-style.sep) * 360deg) / (2 * calc.pi * r)
-      angle -= angle-offset
-    }
-  }
-
-  return (drawables, arc-start, start-angle, stop-angle)
 }

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -45,6 +45,25 @@
     ),
     tip-offset: calculate-tip-offset(style),
     distance: style.length
+  ),
+  stealth: (style) => (
+    drawables: drawable.path(
+      path-util.line-segment(
+        (
+          (0, 0),
+          (style.length, style.width/2),
+          (style.length - style.inset, 0),
+          if not style.harpoon {
+            (style.length, -style.width/2)
+          }
+        ).filter(c => c != none)
+      ),
+      stroke: style.stroke,
+      close: true,
+      fill: style.fill
+    ),
+    distance: style.length - style.inset,
+    tip-offset: calculate-tip-offset(style)
   )
 )
 

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -115,14 +115,15 @@
     style.stroke = util.resolve-stroke(style.stroke)
     style.stroke.thickness = util.resolve-number(ctx, style.stroke.thickness)
 
-    if "angle" in style and style.angle != none {
-      if type(style.angle) == angle {
-        style.width = calc.tan(style.angle / 2) * style.length * 2
-      } else {
-        // (angle, number)
-        style.length = calc.cos(style.angle.first()) * style.angle.last()
-        style.width = calc.sin(style.angle.first() / 2) * 2 * style.angle.last()
-      }
+    if "angle" in style and type(style.angle) == angle {
+      // if type(style.angle) == angle {
+      style.width = calc.tan(style.angle / 2) * style.length * 2
+      // } else {
+      //   // (angle, number)
+      // Tikz gives an example of (90deg, 10pt) but this causes the length to be 0 but does not show that.
+      //   style.length = calc.cos(style.angle.first()) * style.angle.last()
+      //   style.width = calc.sin(style.angle.first() / 2) * 2 * style.angle.last()
+      // }
     }
 
     for (k, v) in style {
@@ -180,21 +181,6 @@
 /// -> A dictionary with the keys:
 ///   - drawables (drawables): The transformed drawables of the mark.
 ///   - distance: The distance between the tip of the mark and the end.
-#let place-mark(style, pos, angle) = {
-  let (drawables, distance, tip-offset) = (marks.at(style.symbol))(style)
-
-  return (
-    drawables: drawable.apply-transform(
-      matrix.mul-mat(
-        matrix.transform-translate(..pos),
-        matrix.transform-rotate-z(angle),
-        matrix.transform-translate(tip-offset, 0, 0)
-      ),
-      drawables
-    ),
-    distance: distance + tip-offset
-  )
-}
 
 #let place-mark-on-path(ctx, styles, segments, is-end: false) = {
   if type(styles) != array {
@@ -285,9 +271,13 @@
     distance.last() = end-distance
   }
   if distance != (0, 0) {
-    segments = path-util.shorten-path(segments, ..distance, mode: if style.flex { "CURVED" } else { "LINEAR" }, samples: style.position-samples)
+    segments = path-util.shorten-path(
+      segments,
+      ..distance,
+      mode: if style.flex { "CURVED" } else { "LINEAR" },
+      samples: style.position-samples
+    )
   }
 
   return (drawables, segments)
-
 }

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -192,7 +192,8 @@
   }
   let distance = 0
   let drawables = ()
-  for style in styles {
+  let len = styles.len()
+  for (i, style) in styles.enumerate() {
     if style.symbol == none {
       continue
     }
@@ -241,7 +242,7 @@
       slant: style.slant, flip: style.flip
     )
     drawables += mark.drawables
-    distance += mark.length
+    distance += mark.length + if i + 1 != len { style.sep }
   }
 
   return (

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -108,6 +108,7 @@
 }
 
 #let place-marks-along-path(ctx, style, segments) = {
+  // panic(segments)
   style = process-style(ctx, style)
   
   let distance = (0, 0)
@@ -120,32 +121,33 @@
     let angle = if style.flex { 
       vector.angle2(pos, path-util.point-on-path(segments, mark.distance, samples: style.position-samples))
     } else {
-      let dir = path-util.direction(segments, 0%)
+      let (_, dir) = path-util.direction(segments, 0%)
       calc.atan2(dir.at(0), dir.at(1))
     }
 
     mark = transform-mark(mark, pos, angle)
     drawables += mark.drawables
-    distance.first() = mark.distance
+    distance.first() = mark.distance + mark.tip-offset
   }
   if style.end != none {
     let mark = (marks.at(style.end))(style)
 
     let pos = path-util.point-on-path(segments, 100%)
-
+    // style.flex = false
     let angle = if style.flex { 
-      vector.angle2(pos, path-util.point-on-path(segments, mark.distance, samples: style.position-samples))
+      vector.angle2(pos, path-util.point-on-path(segments, -mark.distance, samples: style.position-samples))
     } else {
-      let dir = path-util.direction(segments, 100%)
+      let (_, dir) = path-util.direction(segments, 100%)
       calc.atan2(dir.at(0), dir.at(1)) + 180deg
     }
 
     mark = transform-mark(mark, pos, angle)
     drawables += mark.drawables
-    distance.last() = mark.distance
+    distance.last() = mark.distance + mark.tip-offset
   }
 
   segments = path-util.shorten-path(segments, ..distance, mode: if style.flex { "CURVED" } else { "LINEAR" }, samples: style.position-samples)
+  // panic(segments)
 
   return (drawables, segments)
 

--- a/src/mark.typ
+++ b/src/mark.typ
@@ -115,6 +115,16 @@
     style.stroke = util.resolve-stroke(style.stroke)
     style.stroke.thickness = util.resolve-number(ctx, style.stroke.thickness)
 
+    if "angle" in style and style.angle != none {
+      if type(style.angle) == angle {
+        style.width = calc.tan(style.angle / 2) * style.length * 2
+      } else {
+        // (angle, number)
+        style.length = calc.cos(style.angle.first()) * style.angle.last()
+        style.width = calc.sin(style.angle.first() / 2) * 2 * style.angle.last()
+      }
+    }
+
     for (k, v) in style {
       if k in ("length", "width", "inset", "sep") {
         style.insert(k, if type(v) == ratio {

--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -37,6 +37,14 @@
    (0, 0, 0, 1))
 }
 
+// Return 4x4 x-shear matrix
+#let transform-shear-x(factor) = {
+  ((1, factor, 0, 0),
+   (0, 1, 0, 0),
+   (0, 0, 1, 0),
+   (0, 0, 0, 1))
+}
+
 /// Return a $4 times 4$ z-shear matrix
 #let transform-shear-z(factor) = {
   ((1, 0, factor, 0),

--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -129,22 +129,27 @@
    (0,0,0,1))
 }
 
-// Multiply matrix with matrix
-#let mul-mat(a, b) = {
-  let (dim-a, dim-b) = (a, b).map(dim)
-  let (m, n, p) = (
-    ..dim-a,
-    dim-b.last()
-  )
-  (
-    for i in range(m) {
-      (
-        for j in range(p) {
-          (range(n).map(k => a.at(i).at(k) * b.at(k).at(j)).sum(),)
-        }
-      ,)
-    }
-  )
+// Multiply matrices on top of each other.
+#let mul-mat(..matrices) = {
+  // assert(ms.named() == (:), message: "Unexpected named arguments: " + repr(ms.named()))
+  matrices = matrices.pos()
+  let out = matrices.remove(0)
+  for matrix in matrices {
+    let (m, n, p) = (
+      ..dim(out),
+      dim(matrix).last()
+    )
+    out = (
+      for i in range(m) {
+        (
+          for j in range(p) {
+            (range(n).map(k => out.at(i).at(k) * matrix.at(k).at(j)).sum(),)
+          }
+        ,)
+      }
+    )
+  }
+  return out
 }
 
 // Multiply 4x4 matrix with vector of size 3 or 4.

--- a/src/path-util.typ
+++ b/src/path-util.typ
@@ -46,6 +46,8 @@
   return bounds
 }
 
+
+
 /// Calculate length of a single path segment
 ///
 /// - s (array): Path segment
@@ -65,75 +67,152 @@
   }
 }
 
-/// Find point at position on polyline segment.
-/// If the distance t is < 0% or > 100% of the paths length
-/// the start/end point of the path is returned.
-///
-/// - s (array): Polyline path segment
-/// - t (float,ratio): Absolute (float) or relative (ratio) position
-/// -> vector: Position on the polyline
-#let _point-on-polyline(s, t) = {
-  if t == 0 or t == 0% {
-    return s.at(1)
-  } else if t == 100% {
-    return s.last()
-  }
-
-  let len = _segment-length(s)
-  let target = if type(t) == ratio {
-    t * len / 100%
-  } else {
-    t
-  }
-
-  if target <= 0 {
-    return s.at(1)
-  } else if target >= len {
-    return s.last()
-  }
-
-  let traveled = 0
-  for i in range(2, s.len()) {
-    let part = vector.dist(s.at(i - 1), s.at(i))
-
-    if traveled <= target and target <= traveled + part {
-      let t = (target - traveled) / part
-      return vector.add(
-        s.at(i - 1), vector.scale(vector.sub(s.at(i), s.at(i - 1)), t))
-    }
-
-    traveled += part
-  }
-
-  return s.at(1)
-}
-
-/// Get position on path segment
-///
-/// - s (segment): Path segment
-/// - t (float,ratio): Absolute (float) or relative (ratio) position
-///
-/// -> vector: Position on segment as vector clamped to
-///   the segments begin/end position.
-#let _point-on-segment(s, t) = {
-  let (kind, ..pts) = s
-  if kind == "line" {
-    return _point-on-polyline(s, t)
-  } else if kind == "cubic" {
-    let len = t
-    if type(len) == ratio {
-      len = bezier.cubic-arclen(..pts) * calc.min(calc.max(0, t / 100%), 1)
-    }
-    return bezier.cubic-point(..pts, bezier.cubic-t-for-distance(..pts, len))
-  }
-}
-
 /// Get the length of a path
 ///
 /// - segments (array): List of path segments
 /// -> float: Total length of the path
 #let length(segments) = {
   return segments.map(_segment-length).sum()
+}
+
+/// Finds the two points that are between t on a line segment.
+#let _points-between-distance(pts, distance) = {
+  let travelled = 0
+  let length = 0
+  for i in range(1, pts.len()) {
+    length = vector.dist(pts.at(i - 1), pts.at(i))
+    if travelled <= distance and distance <= travelled + length {
+      return (
+        start: i - 1,
+        end: i,
+        distance: distance - travelled,
+        length: length
+      )
+    }
+    travelled += length
+  }
+  return (
+    start: pts.len() - 2,
+    end: pts.len() - 1,
+    distance: length,
+    length: length
+  )
+}
+
+/// Finds the point at a given distance from the start of a line segment. Distances greater than the length of the segment return the end of the line segment. Distances less than zero return the start of the segment.
+///
+/// - segment (array): The line segment
+/// - distance (float): The distance along the line segment to find the point
+/// -> vector: The point on the line segment
+#let _point-on-line-segment(segment, distance) = {
+  let pts = segment.slice(1)
+
+  let (start, end, distance, length) = _points-between-distance(pts, distance)
+  return vector.lerp(pts.at(start), pts.at(end), distance / length)
+  // if t <= 0 or t <= 0% {
+  //   return segment.at(1)
+  // } else if t == 100% {
+  //   return segment.last()
+  // }
+
+  // let length = _segment-length(s)
+  // t = if type(t) == ratio {
+  //   t * length / 100%
+  // }
+
+  // if t >= length {
+  //   return s.last()
+  // }
+
+  // let traveled = 0
+  // for i in range(2, s.len()) {
+  //   let part = vector.dist(s.at(i - 1), s.at(i))
+
+  //   if traveled <= target and target <= traveled + part {
+  //     let t = (target - traveled) / part
+  //     return vector.add(
+  //       s.at(i - 1), vector.scale(vector.sub(s.at(i), s.at(i - 1)), t))
+  //   }
+
+  //   traveled += part
+  // }
+
+  // return s.at(1)
+}
+
+/// Finds the point at a given distance from the start of a path segment. Distances greater than the length of the segment return the end of the path segment. Distances less than zero return the start of the segment.
+///
+/// - segment (segment): Path segment
+/// - distance (float): The distance along the path segment to find the point
+///
+/// -> vector: The point on the path segment
+#let _point-on-segment(segment, distance, length: none) = {
+  let (kind, ..pts) = segment
+  if kind == "line" {
+    return _point-on-line-segment(segment, distance)
+  } else if kind == "cubic" {
+    // if type(t) == ratio {
+      
+    // }
+    // let len = t
+    // if type(len) == ratio {
+    //   len = bezier.cubic-arclen(..pts) * calc.min(calc.max(0, t / 100%), 1)
+    // }
+    return bezier.cubic-point(
+      ..pts,
+      bezier.cubic-t-for-distance(
+        ..pts,
+        if length == none { _segment-length(segment) } else { length } - distance
+      )
+    )
+  }
+}
+
+
+
+#let segment-at-t(segments, t, rev: false) = {
+  let lengths = segments.map(_segment-length)
+  let total = lengths.sum()
+
+  // if segments.len() == 0 {
+  //   return none
+  // } else if t in (0%, 0) {
+  //   return (
+  //     index: 0,
+  //     segment: segments.first(),
+  //     distance: 0
+  //   )
+  // } else if t in (100%, total) {
+  //   return (
+  //     index: segments.len(),
+  //     segment: segments.last(),
+  //     distance: total
+  //   )
+  // }
+
+  if type(t) == ratio {
+    assert(t >= 0% and t <= 100%)
+    t = total * t / 100%
+  } else {
+    assert(t >= 0 and t <= total)
+  }
+
+  if rev {
+    segments = segments.rev()
+  }
+  let travelled = 0
+  for (i, segment-length) in segments.zip(lengths).enumerate() {
+    let (segment, length) = segment-length
+    if travelled <= t and t <= travelled + length {
+      return (
+        index: i,
+        segment: segment,
+        distance: travelled,
+        length: length
+      )
+    }
+    travelled += length
+  }
 }
 
 /// Get position on path
@@ -143,45 +222,51 @@
 ///   float or integer, or relative position if given a ratio from 0% to 100%
 /// -> none,vector: Position on path. If the path is empty (segments == ()), none is returned
 #let point-on-path(segments, t) = {
-  assert(type(t) in (int, float, ratio),
-    message: "Distance t must be of type int, float or ratio")
-  if type(t) == ratio {
-    assert(0% <= t and t <= 100%,
-      message: "Ratio must be between 0% and 100%, got: " + repr(t))
+  assert(
+    type(t) in (int, float, ratio),
+    message: "Distance t must be of type int, float or ratio"
+  )
+  let (distance, segment, length, ..) = segment-at-t(segments, t)
+  return if segment != none {
+    _point-on-segment(segment, t - distance, length: length)
   }
+  // if type(t) == ratio {
+  //   assert(0% <= t and t <= 100%,
+  //     message: "Ratio must be between 0% and 100%, got: " + repr(t))
+  // }
 
-  if segments.len() == 0 {
-    return none
-  } else if segments.len() == 1 {
-    return _point-on-segment(segments.first(), t)
-  }
+  // if segments.len() == 0 {
+  //   return none
+  // } else if segments.len() == 1 {
+  //   return _point-on-segment(segments.first(), t)
+  // }
 
-  let target = if type(t) == ratio {
-    t / 100% * length(segments)
-  } else {
-    assert(0 <= t and t <= length(segments),
-      message: "Absolute distance must be in path range, is: " + repr(t))
-    t
-  }
+  // let target = if type(t) == ratio {
+  //   t / 100% * length(segments)
+  // } else {
+  //   assert(0 <= t and t <= length(segments),
+  //     message: "Absolute distance must be in path range, is: " + repr(t))
+  //   t
+  // }
 
-  if target == 0 {
-    return segment-start(segments.first())
-  }
+  // if target == 0 {
+  //   return segment-start(segments.first())
+  // }
 
   // Total travel distance
-  let traveled = 0
-  for s in segments {
-    let part = _segment-length(s)
+  // let traveled = 0
+  // for s in segments {
+  //   let part = _segment-length(s)
 
-    // This segment contains target
-    if traveled <= target and target <= traveled + part {
-      return _point-on-segment(s, target - traveled)
-    }
+  //   // This segment contains target
+  //   if traveled <= target and target <= traveled + part {
+  //     return _point-on-segment(s, target - traveled)
+  //   }
 
-    traveled += part
-  }
+  //   traveled += part
+  // }
 
-  return segment-end(segments.last())
+  // return segment-end(segments.last())
 }
 
 /// Get position and direction on path
@@ -191,24 +276,20 @@
 ///
 /// - segments (array): List of path segments
 /// - t (float): Position (from 0 to 1)
-/// - scale (float): Scaling factor
 /// -> tuple: Tuple of the point at t and the scaled direction
-#let direction(segments, t, scale: 1) = {
-  let scale = scale
-  let (pt, dir) = (t, t + .001)
-
-  // if at end, use something < 1
-  if t >= 1 {
-    dir = t - .001
-  } else {
-    scale *= -1
-  }
-
-  let (a, b) = (
-    point-on-path(segments, pt * 100%),
-    point-on-path(segments, dir * 100%)
+#let direction(segments, t) = {
+  let (segment, distance, length, ..) = segment-at-t(segments, t)
+  return (
+    _point-on-segment(segment, distance, length: length),
+    if segment.first() == "line" {
+      let (start, end, distance, length) = _points-between-distance(segment.slice(1), distance)
+      vector.norm(vector.sub(segment.at(end+1), segment.at(start+1)))
+    } else {
+      bezier.cubic-derivative(..segment.slice(1), distance / length)
+    }
   )
-  return (a, vector.scale(vector.norm(vector.sub(b, a)), scale))
+
+  // return (a, vector.scale(vector.norm(vector.sub(b, a)), scale))
 }
 
 /// Create a line segment with points
@@ -228,4 +309,64 @@
 /// -> array Segment
 #let cubic-segment(a, b, ctrl-a, ctrl-b) = {
   ("cubic", a, b, ctrl-a, ctrl-b)
+}
+
+/// Shortens a segment by a given distance. If the distance is positive the end of the segment will be moved along the path towards the start of the segment and vice versa if the distance is negative.
+#let shorten-segment(segment, distance) = {
+  let (type, ..s) = segment
+  if type == "line" {
+    let travelled = 0
+    if distance < 0 {
+      s = s.rev()
+    }
+    let prev = s.first()
+    for (i, next) in s.enumerate() {
+      let part = vector.dist(prev, next)
+      if travelled <= distance and (travelled + part) >= distance {
+        
+        segment = (vector.lerp(prev, next, (distance - travelled) / part),) + s.slice(i)
+        break
+      }
+      travelled += part
+      prev = next
+    }
+  } else {
+    segment = bezier.cubic-shorten(..s, distance)
+  }
+  return (type,) + segment
+}
+
+/// Shortens a path's segments by the given distances. The start of the path is shortened first by moving the point along the line towards the end. The end of the path is then shortened in the same way. When a distance is 0 no other calculations are made.
+/// 
+/// - segments (segments): The segments of the path to shorten.
+/// - start-distance (int, float): The distance to shorten from the start of the path.
+/// - end-distance (int, float): The distance to shorten from the end fo the path
+/// -> segments Segments of the path that have been shortened
+#let shorten-path(segments, start-distance, end-distance) = {
+  let total = length(segments)
+  let is-end = false
+  for distance in (start-distance, end-distance) {
+    if distance == 0 {
+      is-end = true
+      continue
+    }
+    if is-end {
+      segments = segments.rev()
+    }
+    let travelled = 0
+    let new = ()
+    for s in segments {
+      let part = _segment-length(s)
+      if travelled <= distance and (travelled + part) >= distance {
+        new.push(shorten-segment(s, (distance - travelled) * if is-end { -1 } else { 1 }))
+        segments = new
+        break
+      }
+      travelled += part
+      new.push(s)
+    }
+    is-end = true
+    total -= distance
+  }
+  return segments
 }

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -26,6 +26,9 @@
     end: none,    // Mark end symbol(s)
     stroke: auto,
     fill: auto,
+    slant: none,
+    flip: false,
+    reverse: false,
     /// If true, the mark points in the direction of the secant from
     /// its base to its tip. If false, the tangent at the marks tip is used.
     flex: true,

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -31,6 +31,7 @@
     harpoon: false,
     flip: false,
     reverse: false,
+    angle: none,
     /// If true, the mark points in the direction of the secant from
     /// its base to its tip. If false, the tangent at the marks tip is used.
     flex: true,

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -24,6 +24,7 @@
     z-up: (0,1,0),// If a mark is pointing to +ve or -ve z, the mark will be drawn with width on the axis perpendicular to its direction and this vector.
     start: none,  // Mark start symbol(s)
     end: none,    // Mark end symbol(s)
+    symbol: none,
     stroke: auto,
     fill: auto,
     slant: none,

--- a/src/styles.typ
+++ b/src/styles.typ
@@ -27,6 +27,7 @@
     stroke: auto,
     fill: auto,
     slant: none,
+    harpoon: false,
     flip: false,
     reverse: false,
     /// If true, the mark points in the direction of the secant from

--- a/src/util.typ
+++ b/src/util.typ
@@ -337,3 +337,28 @@
     .sorted(key: t => t.at(1))
     .map(t => t.at(0))
 }
+
+/// Get stroke as a dictionary with all fields that are missing or auto set to their defaults
+#let get-stroke(stroke) = {
+  if stroke == none {
+    return (paint: none, thickness: 0pt, join: none, cap: none, miter-limit: 4)
+  }
+
+  let default = (
+    paint: black,
+    thickness: 1pt,
+    join: "miter",
+    cap: "butt",
+    miter-limit: 4
+  )
+  let s = line(stroke: stroke).stroke
+  let stroke = (:)
+  for (k, v) in (paint: s.paint, thickness: s.thickness, join: s.join, cap: s.cap, miter-limit: s.miter-limit) {
+    if v == auto {
+      stroke.insert(k, default.at(k))
+    } else {
+      stroke.insert(k, v)
+    }
+  }
+  return s
+}

--- a/src/util.typ
+++ b/src/util.typ
@@ -338,8 +338,8 @@
     .map(t => t.at(0))
 }
 
-/// Get stroke as a dictionary with all fields that are missing or auto set to their defaults
-#let get-stroke(stroke) = {
+/// Resolves a stroke into a usable dictionary with all fields that are missing or auto set to their defaults
+#let resolve-stroke(stroke) = {
   if stroke == none {
     return (paint: none, thickness: 0pt, join: none, cap: none, miter-limit: 4)
   }
@@ -360,5 +360,5 @@
       stroke.insert(k, v)
     }
   }
-  return s
+  return stroke
 }

--- a/src/vector.typ
+++ b/src/vector.typ
@@ -148,3 +148,16 @@
     )
   )
 }
+
+/// Rotate vector of dimension 2 or 3 around the z-axis by angle
+/// - v (vector): Vector to rotate
+/// - angle (angle): Angle
+/// -> vector
+#let rotate-z(v, angle) = {
+  assert(v.len() >= 2,
+    message: "Vector size must be >= 2")
+  let (x, y, ..) = v
+  v.at(0) = x * calc.cos(angle) - y * calc.sin(angle)
+  v.at(1) = x * calc.sin(angle) + y * calc.cos(angle)
+  return v
+}


### PR DESCRIPTION
This does another rework of marks, specifically:

- Move marks into a dictionary of functions.
- Marks are initially drawn at (0,0) pointing towards the left then translated and rotated in the correct direction.
- Rework path utils for finding points on segments
- Unifies mark placement on paths with a single function `place-marks-along-path`

Current progress:
- [x] Proof of concept
- [x] Tip offset
- [x] Improve cubic segment handling (flexing, shortening)
- [x] Add to all mark enabled elements
- [ ] Add more marks
- [ ] Add more styling

I'm basing a lot of the maths and code on #333.