### PR TITLE
scripts: Add script for changing all abs paths

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,8 +4,8 @@
 gallery_dir := "./gallery"
 test_dir := "./tests"
 
-package target:
-  ./scripts/package "{{target}}"
+package target *options:
+  ./scripts/package "{{target}}" {{options}}
 
 install target="@local":
   ./scripts/package "{{target}}"

--- a/scripts/package
+++ b/scripts/package
@@ -24,7 +24,7 @@ else
 fi
 
 if (( $# < 1 )) || [[ "${1:-}" == "help" ]]; then
-  echo "package TARGET"
+  echo "package TARGET [--relative-paths]"
   echo ""
   echo "Packages all relevant files into a directory named '${PKG_PREFIX}/<version>'"
   echo "at TARGET. If TARGET is set to @local, the local Typst package directory"
@@ -45,8 +45,22 @@ function read-toml() {
 }
 
 SOURCE="$(cd "$(dirname "$0")"; pwd -P)/.." # macOS has no realpath
-TARGET="${1:?Missing target path or @local}"
+TARGET="${1:?Missing target path or @local}"; shift
 VERSION="$(read-toml "$SOURCE/typst.toml" "version")"
+
+OPT_RELATIVE_PATHS=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --relative-paths)
+      OPT_RELATIVE_PATHS=true
+      shift
+      ;;
+    *)
+      echo "Unexpected option $1!"
+      exit 1
+      ;;
+  esac
+done
 
 if [[ "$TARGET" == "@local" ]] || [[ "$TARGET" == "install" ]]; then
   TARGET="${DATA_DIR}/typst/packages/local/"
@@ -67,5 +81,11 @@ echo "Packaged to: $TARGET"
 if rm -rf "${TARGET:?}" 2>/dev/null; then
   echo "Overwriting existing version."
 fi
+
+if $OPT_RELATIVE_PATHS; then
+  echo "Changing imports to relative."
+  "$SOURCE/scripts/relpaths" "$TMP"
+fi
+
 mkdir -p "$TARGET"
 mv "$TMP"/* "$TARGET"

--- a/scripts/relpaths
+++ b/scripts/relpaths
@@ -1,0 +1,20 @@
+#!/bin/env python
+import glob, os, sys, re
+
+import_regexp = re.compile(f'#(import|include)\\s*"(/.+)"')
+
+def replace_imports(filename):
+    s = None
+    with open(filename, "r") as file:
+        s = file.read()
+        def abs_to_rel(captures):
+            g = captures.groups()
+            p = os.path.relpath("." + g[1], os.path.dirname(filename))
+            return f'#{g[0]} "{p}"'
+        s = re.sub(import_regexp, abs_to_rel, s)
+    with open(filename, "w") as file:
+        file.write(s)
+
+os.chdir(sys.argv[1])
+for file in glob.iglob("./**/*.typ", recursive=True):
+    replace_imports(file)


### PR DESCRIPTION
This allows installing cetz with all paths in all *.typ files changed to relative ones.
@Andrew15-5: Please test this via `just package <your-directory> --relative-paths`.

As soon as Typst supports changing the package path, this cursed script must get removed.