### PR TITLE
Group external dependencies in single file

### DIFF
--- a/src/anchor.typ
+++ b/src/anchor.typ
@@ -1,4 +1,5 @@
-#import "@preview/oxifmt:0.2.0": strfmt
+#import "deps.typ"
+#import deps.oxifmt: strfmt
 
 #import "util.typ"
 #import "intersection.typ"

--- a/src/coordinate.typ
+++ b/src/coordinate.typ
@@ -1,6 +1,7 @@
-#import "./vector.typ"
-#import "./util.typ"
-#import "@preview/oxifmt:0.2.0": strfmt
+#import "vector.typ"
+#import "util.typ"
+#import "deps.typ"
+#import deps.oxifmt: strfmt
 
 #let resolve-xyz(c) = {
   // (x: <number> or <none>, y: <number> or <none>, z: <number> or <none>)

--- a/src/deps.typ
+++ b/src/deps.typ
@@ -1,0 +1,1 @@
+#import "@preview/oxifmt:0.2.0"

--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -1,5 +1,3 @@
-#import "@preview/oxifmt:0.2.0": strfmt
-
 #import "/src/process.typ"
 #import "/src/intersection.typ"
 #import "/src/path-util.typ"
@@ -10,6 +8,8 @@
 #import "/src/coordinate.typ"
 #import "/src/aabb.typ"
 #import "/src/anchor.typ" as anchor_
+#import "/src/deps.typ"
+#import deps.oxifmt: strfmt
 
 #import "transformations.typ": move-to
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -21,12 +21,3 @@
 #import "lib/angle.typ"
 #import "lib/tree.typ"
 #import "lib/decorations.typ"
-
-// // These are aliases to prevent name collisions
-// // You can use them for importing the module into the
-// // root namespace:
-// //   #import "@.../cetz": canvas, cetz-draw
-// #let cetz-draw = draw
-// #let cetz-tree = tree
-// #let cetz-vector = vector
-// #let cetz-matrix = matrix

--- a/src/util.typ
+++ b/src/util.typ
@@ -1,4 +1,5 @@
-#import "@preview/oxifmt:0.2.0": strfmt
+#import "deps.typ"
+#import deps.oxifmt: strfmt
 
 #import "matrix.typ"
 #import "vector.typ"


### PR DESCRIPTION
Groups dependencies to external libs in a single file to prevent accidentally importing multiple versions.

Fixes #403