### PR TITLE
Made documentations 2D alignment consistent

### DIFF
--- a/src/draw/transformations.typ
+++ b/src/draw/transformations.typ
@@ -216,7 +216,7 @@
 /// circle((5,5))
 /// ```)
 ///
-/// - from (coordinate): Bottom-Left corner coordinate
+/// - from (coordinate): Bottom left corner coordinate
 /// - to (coordinate): Top right corner coordinate
 /// - bounds (vector): Viewport bounds vector that describes the inner width,
 ///   height and depth of the viewport


### PR DESCRIPTION
Alignment terms aren't used with "-" in normal text, only in programs like Typst. And the overall use of alignment terms was inconsistent.
