### PR TITLE
In tree, add "end" and "after-end" as values for parent-position

### DIFF
--- a/src/lib/tree.typ
+++ b/src/lib/tree.typ
@@ -111,7 +111,7 @@
   spread: 1,
   name: none
   ) = {
-  assert(parent-position in ("begin", "center"))
+  assert(parent-position in ("begin", "center","end", "after-end"))
   assert(grow > 0)
   assert(spread > 0)
 
@@ -158,7 +158,7 @@
   // Layout node recursive
   //
   // return:
-  //   (node, left-x, right-x, shift-x)
+  //   (node, left-x, right-x)
   let layout-node(node, shift-x) = {
     if node.children.len() == 0 {
       node.x = shift-x
@@ -181,16 +181,18 @@
         min-x = util.min(min-x, child-min-x)
         max-x = util.max(max-x, child-max-x)
 
-        if child-max-x > right {
-          shift-x = child-max-x
-        }
-        shift-x += spread
+        shift-x = child-max-x + spread
       }
 
       if parent-position == "begin" {
         node.x = left
-      } else {
-        node.x = left + (right - left) / 2
+      } else if parent-position == "center" {
+          node.x = left + (right - left) / 2
+      } else if parent-position == "end" {
+          node.x = right
+      } else { //after-end
+          node.x = right+spread
+          max-x = max-x + spread
       }
 
       node.direct-min-x = left


### PR DESCRIPTION
This solves the issue I created last week (#429) and adds another layout choice where the parent is offset relative to the children.

Both values seem more useful for "right" and "left" direction, and actually, the "after-end" option seems more useful to me, as it allows to render a more hierarchical layout without overlapping, like this question asked on Discord: https://discord.com/channels/1054443721975922748/1193008120688037988

I did not change the existing behavior, but it was very surprising to me to see that when choosing "right" or "left" as direction, the nodes at filled from bottom to top, and it is necessary to choose "end" to have the parent on top. Is it that way for a reason? I would prefer a "before-beginning" rather than "after-end" to indicate that I want my parent above the children, it seems more intuitive to me.