### PR TITLE
lib: Export intersection functions

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -8,6 +8,7 @@
 #import "matrix.typ"
 #import "styles.typ"
 #import "coordinate.typ"
+#import "intersection.typ"
 #import "drawable.typ"
 #import "process.typ"
 #import "util.typ"


### PR DESCRIPTION
Intersection functions should be accessible via `cetz.intersection.*` (requested by the fletcher author).