### PR TITLE
plot: Fix annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@
 - Re-added "a", "b", and "c" anchors for `circle-through`
 - Open arcs are no longer modified for anchors, invalid border anchors will panic.
 - Grids now actually support border anchors.
-- 
+
+## Plot
+- Fixed annotation bounds calculation
 
 # 0.2.0
 CeTZ 0.2.0 requires Typst 0.10.0

--- a/src/lib/plot/annotation.typ
+++ b/src/lib/plot/annotation.typ
@@ -3,6 +3,7 @@
 #import "/src/draw.typ"
 #import "/src/process.typ"
 #import "/src/util.typ"
+#import "/src/matrix.typ"
 
 /// Add an annotation to the plot
 ///
@@ -51,15 +52,14 @@
     return (x, y)
   }
 
+  ctx.transform = matrix.ident()
   let (ctx: ctx, bounds: bounds, drawables: _) = process.many(ctx, annotation.body)
   if bounds == none {
     return (x, y)
   }
 
-  let (x-min, y-max, ..) = bounds.low
-  y-max *= -1
-  let (x-max, y-min, ..) = bounds.high
-  y-min *= -1
+  let (x-min, y-min, ..) = bounds.low
+  let (x-max, y-max, ..) = bounds.high
 
   x-min -= annotation.padding.left
   x-max += annotation.padding.right


### PR DESCRIPTION
Annotation bounds calculation must happen without a transformation, as the coordinates are in plot coordinates.