### PR TITLE
Fix: Prevent divide by zero error if a segment has zero length

### DIFF
--- a/src/path-util.typ
+++ b/src/path-util.typ
@@ -107,12 +107,13 @@
   let pts = segment.slice(1)
 
   let (start, end, distance, length) = _points-between-distance(pts, distance)
-  // length can be zero if start and end are at the same position
-  // this can occur for several reasons, user input, group has zero width or height (not both)
-  if length == 0 {
-    length = 1
+  return if length == 0 {
+    // length can be zero if start and end are at the same position
+    // this can occur for several reasons, user input, group has zero width or height (not both)
+    pts.at(end)
+  } else {
+    vector.lerp(pts.at(start), pts.at(end), distance / length)
   }
-  return vector.lerp(pts.at(start), pts.at(end), distance / length)
 }
 
 /// Finds the point at a given distance from the start of a path segment. Distances greater than the length of the segment return the end of the path segment. Distances less than zero return the start of the segment.

--- a/src/path-util.typ
+++ b/src/path-util.typ
@@ -107,6 +107,11 @@
   let pts = segment.slice(1)
 
   let (start, end, distance, length) = _points-between-distance(pts, distance)
+  // length can be zero if start and end are at the same position
+  // this can occur for several reasons, user input, group has zero width or height (not both)
+  if length == 0 {
+    length = 1
+  }
   return vector.lerp(pts.at(start), pts.at(end), distance / length)
 }
 


### PR DESCRIPTION
I found this bug by attempting to use a path anchor on a group with a vertical line:
```typc
group(name: "g", {
  line((0,0), (0,1))
})
circle("g.start")
```
The group's width becomes zero so some of the points on its bounds are equal. This causes their length to be zero, which causes a divide zero error in `path-util._point-on-line-segment`.

I have fixed this by checking if length is a zero integer and setting it to 1 if so. I'm not sure what other issues this may cause...