### PR TITLE
group: Add cover function for slide animation

### DIFF
--- a/src/draw/grouping.typ
+++ b/src/draw/grouping.typ
@@ -29,8 +29,8 @@
 /// line("i.0", "i.1")
 /// ```)
 ///
-/// - body (element): One or more elements to hide
-#let hide(body) = {
+/// - bounds (bool): If true, respect the bounding box for resizing the canvas
+#let hide(body, bounds: false) = {
   if type(body) == array {
     return body.map(f => {
       (ctx) => {
@@ -38,6 +38,7 @@
         if "drawables" in element {
           element.drawables = element.drawables.map(d => {
             d.hidden = true
+            d.bounds = bounds
             return d
           })
         }

--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -47,7 +47,8 @@
     segments: segments,
     fill: fill,
     stroke: stroke,
-    hidden: false
+    hidden: false,
+    bounds: true,
   )
 }
 
@@ -60,6 +61,7 @@
     segments: border,
     body: body,
     hidden: false,
+    bounds: true,
   )
 }
 

--- a/src/process.typ
+++ b/src/process.typ
@@ -15,7 +15,7 @@
       element.drawables = (element.drawables,)
     }
     for drawable in element.drawables {
-      if not drawable.hidden {
+      if drawable.bounds {
         bounds = aabb.aabb(
           if drawable.type == "path" {
             path-util.bounds(drawable.segments)


### PR DESCRIPTION
The `cover` function is similar to the `hide` function in `cetz`, but it does not affect calculating bounding boxes and `merge-path`. In terms of behavior, it is more similar to the native `hide` function in `typst`. Therefore, the `cover` function is advantageous for `polylux` and `touying` to achieve animations in `cetz` through `uncover` and `pause`.

https://github.com/johannes-wolf/cetz/issues/251#issuecomment-1774005335

```typst
#set page(width: auto, height: auto)
#import "/src/lib.typ": *

#box(stroke: 2pt + red, canvas({
  import draw: *
  rect((0,0), (5,5))

  // Cover a circle
  cover(circle((6,6)))

  // Cover content
  cover(content((-6,-6), [Covered]))

  // Cover multiple elements
  cover({
    rect((0,0), (1,1))
    rect((1,1), (2,2))
    rect((2,2), (3,3))
  })

  // Use covered anchor
  cover(line((0,0), (2.5, 2.5), name: "line"))
  content("line.end", [Covered anchor])
}))
```

![image](https://github.com/johannes-wolf/cetz/assets/34951714/b0f8b79a-c7bc-496d-b8ae-e4dee2f65173)
